### PR TITLE
release v2.1.1 - applika.dev 

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -146,13 +146,21 @@ Use cases encapsulate business operations:
 See `app/application/use_cases/applications/create_application.py` for reference.
 
 ### Authentication
-- GitHub OAuth via `fastapi-sso`
-- **Access-only JWT** stored in HTTP-only cookie (`__access`) — no refresh token
-- Payload: `{sub: github_id, kind: 'access', exp: ...}`
+- GitHub OAuth via `fastapi-sso` with scopes `user:email`, `read:org`
+- **Access token**: short-lived JWT in HTTP-only cookie (`__access`), payload `{sub: github_id, kind: 'access', exp: ...}`
+- **Refresh token**: opaque UUID stored in Redis, referenced via HTTP-only cookie (`__refresh`), TTL configurable (default 7 days)
+- GitHub access token stored **encrypted** (Fernet) in `users.encrypted_github_token` — never logged or exposed
 - `get_current_user()` dependency extracts user from access cookie
-- `GET /auth/refresh` re-issues the cookie if the current token is still valid
-- Token utilities in `app/core/tokens.py`
+- `GET /auth/refresh` validates refresh token from Redis, verifies GitHub token via cached `GET /user`, re-issues access cookie; invalidates session if GitHub token revoked
+- `GET /auth/logout` revokes refresh token from Redis and clears both cookies
+- Token utilities in `app/core/tokens.py`, encryption in `app/core/crypto.py`
 - Cookie settings: HTTPOnly, Secure in PROD, SameSite=Lax
+
+### GitHub Integration
+- `GitHubService` (`app/application/services/github_service.py`) validates tokens and checks org membership
+- Redis cache with configurable TTL (default 10 min) for `github:token_valid:{user_id}` and `github:org_member:{user_id}`
+- Org membership checked on login (fresh) and report submission (cached)
+- Discord report webhook only fires for confirmed org members
 
 ### Exception Handling
 Domain exceptions in `app/core/exceptions.py`:
@@ -271,6 +279,11 @@ Optional (with defaults):
 - `ACCESS_TOKEN_EXPIRE_MINUTES`: 15 (default)
 - `GITHUB_REDIRECT_URI`: OAuth callback URL
 - `LOGIN_REDIRECT_URI`: Post-login redirect
+- `REFRESH_TOKEN_EXPIRE_DAYS`: Refresh token TTL in days (default: 7)
+- `REDIS_URL`: Redis connection URL (default: redis://localhost:6379/0)
+- `GITHUB_CACHE_TTL_SECONDS`: Redis cache TTL for GitHub API checks (default: 600)
+- `GITHUB_TOKEN_ENCRYPTION_KEY`: Fernet key for encrypting GitHub tokens (generate with `python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"`)
+- `DISCORD_REPORTS_ORGANIZATION`: GitHub org name; only org members get reports posted to Discord
 - `DISCORD_REPORTS_WEBHOOK`: Discord webhook for biweekly reports
 - `DISCORD_FEEDBACK_WEBHOOK`: Discord webhook for user feedback
 - `CORS_ORIGINS`, `CORS_HEADERS`, `CORS_METHODS`: CORS configuration

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -158,8 +158,7 @@ See `app/application/use_cases/applications/create_application.py` for reference
 
 ### GitHub Integration
 - `GitHubService` (`app/application/services/github_service.py`) validates tokens and checks org membership
-- Redis cache with configurable TTL (default 10 min) for `github:token_valid:{user_id}` and `github:org_member:{user_id}`
-- Org membership checked on login (fresh) and report submission (cached)
+- Redis cache with configurable TTL (default 10 min) for `applika:github:token_valid:{user_id}`
 - Discord report webhook only fires for confirmed org members
 
 ### Exception Handling
@@ -186,9 +185,9 @@ All entity primary keys use Snowflake-generated `BigInteger` IDs instead of UUID
 | Method | Route | Auth | Description |
 |--------|-------|------|-------------|
 | GET | `/auth/github/login` | No | Redirect to GitHub OAuth |
-| GET | `/auth/github/callback` | No | OAuth callback, sets access cookie |
-| GET | `/auth/refresh` | Yes | Re-issue access cookie |
-| GET | `/auth/logout` | No | Clear access cookie |
+| GET | `/auth/github/callback` | No | OAuth callback, sets access + refresh cookies |
+| GET | `/auth/refresh` | No | Validate refresh token, re-issue access cookie |
+| GET | `/auth/logout` | No | Revoke refresh token, clear both cookies |
 
 ### Users (`/users`)
 | Method | Route | Auth | Description |

--- a/backend/README.md
+++ b/backend/README.md
@@ -64,7 +64,9 @@ backend/
 - **Pydantic** 2.0 for validation and settings
 - **Snowflake IDs** for distributed unique identifiers
 - **fastapi-sso** for GitHub OAuth
+- **Redis** 7 for refresh tokens and caching
 - **PyJWT** for token management
+- **cryptography** (Fernet) for GitHub token encryption
 
 ## Required Environment Variables
 
@@ -82,16 +84,22 @@ backend/
 | `JWT_SECRET` | JWT signing secret | changeme placeholder |
 | `JWT_ALGORITHM` | JWT algorithm | `HS256` |
 | `ACCESS_TOKEN_EXPIRE_MINUTES` | Access token TTL | `15` |
+| `REFRESH_TOKEN_EXPIRE_DAYS` | Refresh token TTL in days | `7` |
+| `REDIS_URL` | Redis connection URL | `redis://localhost:6379/0` |
 | `GITHUB_REDIRECT_URI` | OAuth callback URL | `http://127.0.0.1:8000/api/auth/github/callback` |
+| `GITHUB_CACHE_TTL_SECONDS` | Redis cache TTL for GitHub API checks | `600` |
+| `GITHUB_TOKEN_ENCRYPTION_KEY` | Fernet key for encrypting GitHub tokens | changeme placeholder |
+| `DISCORD_REPORTS_ORGANIZATION` | GitHub org for gating Discord report webhook | `None` |
 | `LOGIN_REDIRECT_URI` | Post-login redirect | `http://127.0.0.1:8000/api/docs` |
 | `DISCORD_REPORTS_WEBHOOK` | Discord webhook for biweekly reports | `None` |
 | `DISCORD_FEEDBACK_WEBHOOK` | Discord webhook for user feedback | `None` |
-| `CORS_ORIGINS` | Allowed CORS origins | `["http://127.0.0.1:3000","http://127.0.0.1:8000"]` |
+| `CORS_ORIGINS` | Allowed CORS origins | `["http://127.0.0.1:8080","http://127.0.0.1:8000"]` |
 | `CORS_HEADERS` | Allowed CORS headers | `["X-Request-ID","Content-Type"]` |
 | `CORS_METHODS` | Allowed CORS methods | `["GET","PATCH","POST","PUT","DELETE","OPTIONS"]` |
 | `API_PREFIX` | API route prefix | `/api` |
 | `LOG_LEVEL` | Logging level | `INFO` |
 | `LOG_FORMAT` | Logging format string | `[%(asctime)s] \|%(levelname)s\| ...` |
+| `LOG_FILE` | JSON log file path | `logs/app.log` |
 | `DATABASE_ECHO` | SQLAlchemy echo flag | `False` |
 
 ## How to Run
@@ -111,7 +119,7 @@ backend/
    ```bash
    docker compose up --build
    ```
-   The entrypoint automatically runs migrations before starting the server.
+   This starts the backend, PostgreSQL, and Redis. The entrypoint automatically runs migrations before starting the server.
 
 4. **Access the API:** `http://127.0.0.1:8000/api/docs`
 
@@ -150,12 +158,14 @@ python scripts/seed_mock_data.py
 
 ## Authentication
 
-The API uses GitHub OAuth with access-only JWT cookies (no refresh token):
+The API uses GitHub OAuth with JWT access cookies and Redis-backed refresh tokens:
 
 1. `GET /api/auth/github/login` — Redirects to GitHub
-2. GitHub callback sets an `__access` HTTPOnly cookie
-3. `GET /api/auth/refresh` — Re-issues the cookie if still valid
-4. `GET /api/auth/logout` — Clears the cookie
+2. GitHub callback sets an `__access` HTTPOnly JWT cookie and a `__refresh` HTTPOnly cookie (opaque UUID stored in Redis)
+3. `GET /api/auth/refresh` — Validates refresh token from Redis, verifies GitHub token, re-issues access cookie
+4. `GET /api/auth/logout` — Revokes refresh token from Redis and clears both cookies
+
+GitHub access tokens are stored **encrypted** (Fernet) in the database and never exposed.
 
 ### Creating a GitHub OAuth App
 

--- a/backend/app/application/dto/user.py
+++ b/backend/app/application/dto/user.py
@@ -33,6 +33,7 @@ class UserDTO(BaseSchema):
     availability: Availability | None = None
     bio: str | None = None
     linkedin_url: str | None = None
+    is_org_member: bool = False
 
 
 class UserUpdateDTO(BaseModel):

--- a/backend/app/application/services/github_service.py
+++ b/backend/app/application/services/github_service.py
@@ -18,7 +18,7 @@ class GitHubService:
     _API_BASE = 'https://api.github.com'
     _HEADERS = {
         'Accept': 'application/vnd.github+json',
-        'X-GitHub-Api-Version': '2022-11-28',
+        'X-GitHub-Api-Version': '2026-03-10',
     }
 
     def __init__(self, redis_client: redis.Redis):
@@ -33,7 +33,7 @@ class GitHubService:
         self, user_id: int, github_token: str
     ) -> bool:
         """Check if a GitHub token is still valid. Cached per user."""
-        cache_key = f'github:token_valid:{user_id}'
+        cache_key = f'applika:github:token_valid:{user_id}'
 
         cached = await self.redis.get(cache_key)
         if cached is not None:
@@ -53,23 +53,18 @@ class GitHubService:
             )
             is_valid = False
 
-        await self.redis.set(
-            cache_key, '1' if is_valid else '0', ex=self.cache_ttl
-        )
+        if user_id:
+            await self.redis.set(
+                cache_key, '1' if is_valid else '0', ex=self.cache_ttl
+            )
         return is_valid
 
     async def check_org_membership(
-        self, user_id: int, github_token: str
+        self, github_token: str
     ) -> bool:
-        """Check if user belongs to the configured org. Cached per user."""
+        """Check if user belongs to the configured org. Not cached."""
         if not self.org_name:
             return False
-
-        cache_key = f'github:org_member:{user_id}'
-
-        cached = await self.redis.get(cache_key)
-        if cached is not None:
-            return cached == '1'
 
         try:
             async with httpx.AsyncClient() as client:
@@ -77,6 +72,10 @@ class GitHubService:
                     f'{self._API_BASE}/user/orgs',
                     headers=self._auth_headers(github_token),
                     timeout=10,
+                )
+                logger.debug(
+                    'GitHub /user/orgs response: \n' +
+                    f'{response.status_code} - {response.text}'
                 )
                 if response.status_code != 200:
                     logger.warning(
@@ -96,14 +95,10 @@ class GitHubService:
             )
             is_member = False
 
-        await self.redis.set(
-            cache_key, '1' if is_member else '0', ex=self.cache_ttl
-        )
         return is_member
 
     async def invalidate_cache(self, user_id: int) -> None:
         """Remove all cached GitHub data for a user."""
         await self.redis.delete(
-            f'github:token_valid:{user_id}',
-            f'github:org_member:{user_id}',
+            f'applika:github:token_valid:{user_id}',
         )

--- a/backend/app/application/services/github_service.py
+++ b/backend/app/application/services/github_service.py
@@ -1,0 +1,109 @@
+"""GitHub API service with Redis-cached validation.
+
+Provides methods to:
+- Validate a GitHub access token (GET /user)
+- Check organization membership (GET /user/orgs)
+
+Both results are cached in Redis to avoid excessive GitHub API calls.
+"""
+
+import httpx
+import redis.asyncio as redis
+
+from app.config.logging import logger
+from app.config.settings import envs
+
+
+class GitHubService:
+    _API_BASE = 'https://api.github.com'
+    _HEADERS = {
+        'Accept': 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+    }
+
+    def __init__(self, redis_client: redis.Redis):
+        self.redis = redis_client
+        self.cache_ttl = envs.GITHUB_CACHE_TTL_SECONDS
+        self.org_name = envs.DISCORD_REPORTS_ORGANIZATION
+
+    def _auth_headers(self, token: str) -> dict:
+        return {**self._HEADERS, 'Authorization': f'Bearer {token}'}
+
+    async def validate_token(
+        self, user_id: int, github_token: str
+    ) -> bool:
+        """Check if a GitHub token is still valid. Cached per user."""
+        cache_key = f'github:token_valid:{user_id}'
+
+        cached = await self.redis.get(cache_key)
+        if cached is not None:
+            return cached == '1'
+
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.get(
+                    f'{self._API_BASE}/user',
+                    headers=self._auth_headers(github_token),
+                    timeout=10,
+                )
+                is_valid = response.status_code == 200
+        except httpx.HTTPError as exc:
+            logger.error(
+                f'GitHub token validation failed: {exc}'
+            )
+            is_valid = False
+
+        await self.redis.set(
+            cache_key, '1' if is_valid else '0', ex=self.cache_ttl
+        )
+        return is_valid
+
+    async def check_org_membership(
+        self, user_id: int, github_token: str
+    ) -> bool:
+        """Check if user belongs to the configured org. Cached per user."""
+        if not self.org_name:
+            return False
+
+        cache_key = f'github:org_member:{user_id}'
+
+        cached = await self.redis.get(cache_key)
+        if cached is not None:
+            return cached == '1'
+
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.get(
+                    f'{self._API_BASE}/user/orgs',
+                    headers=self._auth_headers(github_token),
+                    timeout=10,
+                )
+                if response.status_code != 200:
+                    logger.warning(
+                        'GitHub /user/orgs returned '
+                        f'status {response.status_code}'
+                    )
+                    is_member = False
+                else:
+                    orgs = response.json()
+                    is_member = any(
+                        org.get('login') == self.org_name
+                        for org in orgs
+                    )
+        except httpx.HTTPError as exc:
+            logger.error(
+                f'GitHub org membership check failed: {exc}'
+            )
+            is_member = False
+
+        await self.redis.set(
+            cache_key, '1' if is_member else '0', ex=self.cache_ttl
+        )
+        return is_member
+
+    async def invalidate_cache(self, user_id: int) -> None:
+        """Remove all cached GitHub data for a user."""
+        await self.redis.delete(
+            f'github:token_valid:{user_id}',
+            f'github:org_member:{user_id}',
+        )

--- a/backend/app/application/use_cases/application_steps/create_application_step.py
+++ b/backend/app/application/use_cases/application_steps/create_application_step.py
@@ -3,7 +3,6 @@ from app.application.dto.application_step import (
     ApplicationStepCreateDTO,
     ApplicationStepDTO,
 )
-from app.application.validators.application_date import ensure_not_in_future
 from app.config.logging import logger
 from app.core.exceptions import (
     ApplicationFinalized,
@@ -64,8 +63,6 @@ class CreateApplicationStepUseCase:
     async def execute(
         self, user_id: int, data: ApplicationStepCreateDTO
     ) -> ApplicationDTO:
-        ensure_not_in_future(data.step_date, 'step_date')
-
         application = await self.application_repo.get_by_id_and_user_id(
             data.application_id, user_id
         )

--- a/backend/app/application/use_cases/application_steps/update_application_step.py
+++ b/backend/app/application/use_cases/application_steps/update_application_step.py
@@ -3,7 +3,6 @@ from app.application.dto.application_step import (
     ApplicationStepDTO,
     ApplicationStepUpdateDTO,
 )
-from app.application.validators.application_date import ensure_not_in_future
 from app.core.exceptions import (
     ApplicationFinalized,
     BusinessRuleViolation,
@@ -78,8 +77,6 @@ class UpdateApplicationStepUseCase:
     async def execute(
         self, id: int, user_id: int, data: ApplicationStepUpdateDTO
     ) -> ApplicationDTO:
-        ensure_not_in_future(data.step_date, 'step_date')
-
         application = await self.application_repo.get_by_id_and_user_id(
             data.application_id, user_id
         )

--- a/backend/app/application/use_cases/quinzenal_reports/submit_report.py
+++ b/backend/app/application/use_cases/quinzenal_reports/submit_report.py
@@ -9,6 +9,7 @@ from app.application.dto.quinzenal_report import (
     SubmitReportResultDTO,
 )
 from app.application.services.discord_service import DiscordService
+from app.application.services.github_service import GitHubService
 from app.application.use_cases.quinzenal_reports.common import (
     get_current_day,
     get_next_report_day,
@@ -16,11 +17,13 @@ from app.application.use_cases.quinzenal_reports.common import (
     get_report_period,
 )
 from app.config.logging import logger
+from app.core.crypto import decrypt_token
 from app.core.exceptions import ResourceConflict
 from app.domain.models import QuinzenalReportModel
 from app.domain.repositories.quinzenal_report_repository import (
     QuinzenalReportRepository,
 )
+from app.domain.repositories.user_repository import UserRepository
 
 
 class SubmitReportUseCase:
@@ -30,9 +33,13 @@ class SubmitReportUseCase:
         self,
         report_repo: QuinzenalReportRepository,
         discord_service: DiscordService,
+        github_service: GitHubService,
+        user_repo: UserRepository,
     ):
         self.report_repo = report_repo
         self.discord_service = discord_service
+        self.github_service = github_service
+        self.user_repo = user_repo
 
     @classmethod
     def _sanitize_discord_text(cls, text: str, *, max_length: int) -> str:
@@ -111,13 +118,30 @@ class SubmitReportUseCase:
             f'🎯 **NEXT FORTNIGHT GOAL:** {safe_next_fortnight_goal}'
         )
 
+    async def _validate_org_membership(
+        self, user_id: int
+    ) -> bool:
+        """Check if the user is an org member via their stored GitHub
+        token. Returns False if the user has no token or the check
+        fails — never cached for non-members."""
+        user = await self.user_repo.get_by_id(user_id)
+        if not user or not user.encrypted_github_token:
+            return False
+
+        github_token = decrypt_token(user.encrypted_github_token)
+        if not github_token:
+            return False
+
+        return await self.github_service.check_org_membership(
+            github_token
+        )
+
     async def execute(
         self,
         user_id: int,
         username: str,
         report_day: ReportDays,
         payload: SubmitReportPayloadDTO,
-        is_org_member: bool = False,
     ) -> SubmitReportResultDTO:
         # Start date is only used in the first day of the report
         if report_day > 1:
@@ -217,6 +241,7 @@ class SubmitReportUseCase:
         discord_posted = False
         discord_error = None
 
+        is_org_member = await self._validate_org_membership(user_id)
         if is_org_member:
             discord_message = self._build_discord_message(
                 report_day=report_day,

--- a/backend/app/application/use_cases/quinzenal_reports/submit_report.py
+++ b/backend/app/application/use_cases/quinzenal_reports/submit_report.py
@@ -117,6 +117,7 @@ class SubmitReportUseCase:
         username: str,
         report_day: ReportDays,
         payload: SubmitReportPayloadDTO,
+        is_org_member: bool = False,
     ) -> SubmitReportResultDTO:
         # Start date is only used in the first day of the report
         if report_day > 1:
@@ -213,20 +214,28 @@ class SubmitReportUseCase:
 
         saved_report = await self.report_repo.create(report)
 
-        discord_message = self._build_discord_message(
-            report_day=report_day,
-            username=username,
-            phase=report.phase,
-            metrics=metrics,
-            payload=payload,
-        )
-        discord_posted, discord_error = (
-            await self.discord_service.post_report_message(discord_message)
-        )
+        discord_posted = False
+        discord_error = None
 
-        if discord_posted and not saved_report.discord_posted:
-            saved_report.discord_posted = True
-            saved_report = await self.report_repo.update(saved_report)
+        if is_org_member:
+            discord_message = self._build_discord_message(
+                report_day=report_day,
+                username=username,
+                phase=report.phase,
+                metrics=metrics,
+                payload=payload,
+            )
+            discord_posted, discord_error = (
+                await self.discord_service.post_report_message(
+                    discord_message
+                )
+            )
+
+            if discord_posted and not saved_report.discord_posted:
+                saved_report.discord_posted = True
+                saved_report = await self.report_repo.update(
+                    saved_report
+                )
 
         logger.info(
             f'Report day {report_day} submitted successfully',

--- a/backend/app/application/use_cases/refresh_token.py
+++ b/backend/app/application/use_cases/refresh_token.py
@@ -1,0 +1,78 @@
+import redis.asyncio as redis
+from fastapi import HTTPException, Response, status
+
+from app.application.services.github_service import GitHubService
+from app.core.crypto import decrypt_token
+from app.core.tokens import (
+    clear_access_cookie,
+    clear_refresh_cookie,
+    revoke_refresh_token,
+    set_access_cookie,
+    validate_refresh_token,
+)
+from app.domain.repositories.user_repository import UserRepository
+
+
+class RefreshTokenUseCase:
+    def __init__(
+        self,
+        user_repo: UserRepository,
+        gh_service: GitHubService,
+        redis_client: redis.Redis,
+    ):
+        self.user_repo = user_repo
+        self.gh_service = gh_service
+        self.redis_client = redis_client
+
+    async def execute(
+        self, refresh_id: str | None, response: Response
+    ) -> None:
+        """Validate refresh token, verify GitHub token, re-issue
+        access cookie. Raises HTTPException on failure."""
+        if not refresh_id:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail='Not authenticated',
+            )
+
+        user_id = await validate_refresh_token(
+            refresh_id, self.redis_client
+        )
+        if user_id is None:
+            clear_access_cookie(response)
+            clear_refresh_cookie(response)
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail='Invalid or expired refresh token',
+            )
+
+        user = await self.user_repo.get_by_id(user_id)
+        if not user:
+            await revoke_refresh_token(
+                refresh_id, self.redis_client
+            )
+            clear_access_cookie(response)
+            clear_refresh_cookie(response)
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail='User not found',
+            )
+
+        if user.encrypted_github_token:
+            github_token = decrypt_token(user.encrypted_github_token)
+            if github_token:
+                is_valid = await self.gh_service.validate_token(
+                    user.id, github_token
+                )
+                if not is_valid:
+                    await revoke_refresh_token(
+                        refresh_id, self.redis_client
+                    )
+                    clear_access_cookie(response)
+                    clear_refresh_cookie(response)
+                    raise HTTPException(
+                        status_code=status.HTTP_401_UNAUTHORIZED,
+                        detail='GitHub token revoked',
+                    )
+
+        set_access_cookie(str(user.github_id), response)

--- a/backend/app/application/use_cases/user_registration.py
+++ b/backend/app/application/use_cases/user_registration.py
@@ -2,6 +2,7 @@ from fastapi_sso import OpenID
 
 from app.application.dto.user import UserCreateDTO, UserDTO
 from app.config.logging import logger
+from app.core.crypto import encrypt_token
 from app.domain.repositories.user_repository import UserRepository
 
 
@@ -9,17 +10,30 @@ class UserRegistrationUseCase:
     def __init__(self, user_repository: UserRepository):
         self.user_repository = user_repository
 
-    async def execute(self, user: OpenID) -> UserDTO:
+    async def execute(
+        self,
+        user: OpenID,
+        github_token: str | None = None,
+        is_org_member: bool = False,
+    ) -> UserDTO:
         existing_user = await self.user_repository.get_by_github_id(
             int(user.id)
         )
         if existing_user:
+            if github_token:
+                existing_user.encrypted_github_token = encrypt_token(
+                    github_token
+                )
+            existing_user.is_org_member = is_org_member
+            await self.user_repository.update(existing_user)
+
             logger.info(
                 f'Returning user login: {existing_user.username}',
                 extra={'extra_data': {
                     'event': 'user_login',
                     'user_id': existing_user.id,
                     'github_id': user.id,
+                    'is_org_member': is_org_member,
                 }},
             )
             return UserDTO.model_validate(existing_user)
@@ -31,6 +45,14 @@ class UserRegistrationUseCase:
         )
 
         created_user = await self.user_repository.create(user_data)
+
+        if github_token:
+            created_user.encrypted_github_token = encrypt_token(
+                github_token
+            )
+        created_user.is_org_member = is_org_member
+        await self.user_repository.update(created_user)
+
         logger.info(
             f'New user registered: {created_user.username}',
             extra={'extra_data': {
@@ -38,6 +60,7 @@ class UserRegistrationUseCase:
                 'user_id': created_user.id,
                 'github_id': user.id,
                 'username': user.display_name,
+                'is_org_member': is_org_member,
             }},
         )
         return UserDTO.model_validate(created_user)

--- a/backend/app/config/redis.py
+++ b/backend/app/config/redis.py
@@ -1,0 +1,18 @@
+"""Redis client configuration.
+
+Provides an async Redis client for caching GitHub token validation
+and organization membership checks.
+"""
+
+import redis.asyncio as redis
+
+from app.config.settings import envs
+
+redis_client = redis.from_url(
+    envs.REDIS_URL,
+    decode_responses=True,
+)
+
+
+async def get_redis() -> redis.Redis:
+    return redis_client

--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -4,6 +4,7 @@ from pydantic import Field, PostgresDsn, UrlConstraints
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 ACCESS_COOKIE_NAME = '__access'
+REFRESH_COOKIE_NAME = '__refresh'
 
 EnvType = Literal['PROD', 'DEV', 'TEST']
 
@@ -61,6 +62,16 @@ class Settings(BaseSettings):
     GITHUB_CLIENT_ID: str
     GITHUB_CLIENT_SECRET: str
     GITHUB_REDIRECT_URI: str = 'http://127.0.0.1:8000/api/auth/github/callback'
+
+    REFRESH_TOKEN_EXPIRE_DAYS: int = 7
+
+    REDIS_URL: str = 'redis://localhost:6379/0'
+    GITHUB_CACHE_TTL_SECONDS: int = 600  # 10 minutes
+
+    GITHUB_TOKEN_ENCRYPTION_KEY: str = (
+        'changeme-set-a-fernet-key-in-production'
+    )
+    DISCORD_REPORTS_ORGANIZATION: str | None = None
 
     LOGIN_REDIRECT_URI: str = 'http://127.0.0.1:8000/api/docs'
     DISCORD_REPORTS_WEBHOOK: str | None = None

--- a/backend/app/core/crypto.py
+++ b/backend/app/core/crypto.py
@@ -1,0 +1,27 @@
+"""Fernet-based encryption for sensitive tokens.
+
+Used to encrypt/decrypt GitHub access tokens stored in the database.
+The encryption key must be a valid Fernet key (base64-encoded 32 bytes).
+Generate one with: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+"""
+
+from cryptography.fernet import Fernet, InvalidToken
+
+from app.config.settings import envs
+
+
+def _get_fernet() -> Fernet:
+    return Fernet(envs.GITHUB_TOKEN_ENCRYPTION_KEY.encode())
+
+
+def encrypt_token(plaintext: str) -> str:
+    """Encrypt a plaintext token and return the ciphertext as a string."""
+    return _get_fernet().encrypt(plaintext.encode()).decode()
+
+
+def decrypt_token(ciphertext: str) -> str | None:
+    """Decrypt a ciphertext token. Returns None if decryption fails."""
+    try:
+        return _get_fernet().decrypt(ciphertext.encode()).decode()
+    except InvalidToken:
+        return None

--- a/backend/app/core/tokens.py
+++ b/backend/app/core/tokens.py
@@ -1,10 +1,23 @@
+"""JWT token utilities and cookie management.
+
+Access token: short-lived JWT in HTTP-only cookie (__access).
+Refresh token: opaque UUID stored in Redis, referenced via HTTP-only
+cookie (__refresh).
+"""
+
+import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Literal, TypedDict
 
 import jwt
+import redis.asyncio as redis
 from fastapi import Response
 
-from app.config.settings import ACCESS_COOKIE_NAME, envs
+from app.config.settings import (
+    ACCESS_COOKIE_NAME,
+    REFRESH_COOKIE_NAME,
+    envs,
+)
 
 
 class TokenPayload(TypedDict):
@@ -46,3 +59,57 @@ def set_access_cookie(sub: str, response: Response):
 
 def clear_access_cookie(response: Response):
     response.delete_cookie(ACCESS_COOKIE_NAME)
+
+
+# --- Refresh token (Redis-backed) ---
+
+_REFRESH_PREFIX = 'refresh_token:'
+
+
+def _refresh_key(token_id: str) -> str:
+    return f'{_REFRESH_PREFIX}{token_id}'
+
+
+async def create_refresh_token(
+    user_id: int, redis_client: redis.Redis, response: Response
+) -> str:
+    """Generate a refresh token, store in Redis, set cookie."""
+    token_id = str(uuid.uuid4())
+    ttl_seconds = envs.REFRESH_TOKEN_EXPIRE_DAYS * 86400
+
+    await redis_client.set(
+        _refresh_key(token_id),
+        str(user_id),
+        ex=ttl_seconds,
+    )
+
+    response.set_cookie(
+        key=REFRESH_COOKIE_NAME,
+        value=token_id,
+        httponly=True,
+        secure=envs.ENVIRONMENT == 'PROD',
+        samesite='lax',
+        max_age=ttl_seconds,
+    )
+    return token_id
+
+
+async def validate_refresh_token(
+    token_id: str, redis_client: redis.Redis
+) -> int | None:
+    """Validate refresh token. Returns user_id if valid, else None."""
+    user_id_str = await redis_client.get(_refresh_key(token_id))
+    if user_id_str is None:
+        return None
+    return int(user_id_str)
+
+
+async def revoke_refresh_token(
+    token_id: str, redis_client: redis.Redis
+) -> None:
+    """Revoke a refresh token by deleting it from Redis."""
+    await redis_client.delete(_refresh_key(token_id))
+
+
+def clear_refresh_cookie(response: Response):
+    response.delete_cookie(REFRESH_COOKIE_NAME)

--- a/backend/app/core/tokens.py
+++ b/backend/app/core/tokens.py
@@ -63,7 +63,7 @@ def clear_access_cookie(response: Response):
 
 # --- Refresh token (Redis-backed) ---
 
-_REFRESH_PREFIX = 'refresh_token:'
+_REFRESH_PREFIX = 'applika:refresh_token:'
 
 
 def _refresh_key(token_id: str) -> str:

--- a/backend/app/domain/models.py
+++ b/backend/app/domain/models.py
@@ -91,6 +91,12 @@ class UserModel(BaseMixin, Base):
     )
     bio: Mapped[Optional[str]] = mapped_column(sa.Text)
     linkedin_url: Mapped[Optional[str]] = mapped_column(sa.String(500))
+    encrypted_github_token: Mapped[Optional[str]] = mapped_column(
+        sa.Text, nullable=True
+    )
+    is_org_member: Mapped[bool] = mapped_column(
+        sa.Boolean, default=False, server_default='false', nullable=False
+    )
 
     applications: Mapped[List['ApplicationModel']] = relationship(
         back_populates='user'

--- a/backend/app/presentation/api/oauth.py
+++ b/backend/app/presentation/api/oauth.py
@@ -3,10 +3,25 @@ from fastapi import APIRouter, HTTPException, Request, Response, status
 from fastapi.responses import RedirectResponse
 from fastapi_sso.sso.github import GithubSSO
 
-from app.application.use_cases.user_registration import UserRegistrationUseCase
-from app.config.settings import ACCESS_COOKIE_NAME, envs
-from app.core.tokens import clear_access_cookie, decode_token, set_access_cookie
-from app.presentation.dependencies import UserRepositoryDp
+from app.application.services.github_service import GitHubService
+from app.application.use_cases.user_registration import (
+    UserRegistrationUseCase,
+)
+from app.config.settings import REFRESH_COOKIE_NAME, envs
+from app.core.crypto import decrypt_token
+from app.core.tokens import (
+    clear_access_cookie,
+    clear_refresh_cookie,
+    create_refresh_token,
+    revoke_refresh_token,
+    set_access_cookie,
+    validate_refresh_token,
+)
+from app.presentation.dependencies import (
+    GitHubServiceDp,
+    RedisDp,
+    UserRepositoryDp,
+)
 from app.presentation.schemas import DetailSchema
 
 router = APIRouter(prefix='/auth', tags=['OAuth'])
@@ -17,6 +32,7 @@ github_sso = GithubSSO(
     client_secret=envs.GITHUB_CLIENT_SECRET,
     redirect_uri=envs.GITHUB_REDIRECT_URI,
     allow_insecure_http=True,
+    scope=['user:email', 'read:org'],
 )
 
 
@@ -29,21 +45,43 @@ async def auth_init():
 
 @router.get('/github/callback')
 async def auth_callback(
-    request: Request, response: Response, user_repo: UserRepositoryDp
+    request: Request,
+    response: Response,
+    user_repo: UserRepositoryDp,
+    gh_service: GitHubServiceDp,
+    redis_client: RedisDp,
 ):
-    """Verify login"""
+    """Verify login, store encrypted GitHub token, issue tokens."""
     async with github_sso:
         user = await github_sso.verify_and_process(request)
         if not user:
             raise HTTPException(
                 status_code=401, detail='Authentication failed'
             )
+        github_token = github_sso.oauth_client.token.get(
+            'access_token'
+        )
+
+    # Check org membership with the fresh GitHub token
+    is_org_member = False
+    if github_token and envs.DISCORD_REPORTS_ORGANIZATION:
+        is_org_member = await gh_service.check_org_membership(
+            0, github_token  # user_id=0 skips cache on first check
+        )
 
     use_case = UserRegistrationUseCase(user_repo)
-    user_data = await use_case.execute(user)
+    user_data = await use_case.execute(
+        user,
+        github_token=github_token,
+        is_org_member=is_org_member,
+    )
+
+    # Invalidate any stale cache for this user
+    await gh_service.invalidate_cache(user_data.id)
 
     response = RedirectResponse(envs.LOGIN_REDIRECT_URI)
     set_access_cookie(str(user_data.github_id), response)
+    await create_refresh_token(user_data.id, redis_client, response)
 
     return response
 
@@ -53,34 +91,70 @@ async def auth_callback(
     response_model=DetailSchema,
     responses={'401': {'model': DetailSchema}},
 )
-def refresh_token(request: Request, response: Response):
-    access_token = request.cookies.get(ACCESS_COOKIE_NAME)
-    if not access_token:
+async def refresh_token(
+    request: Request,
+    response: Response,
+    user_repo: UserRepositoryDp,
+    gh_service: GitHubServiceDp,
+    redis_client: RedisDp,
+):
+    """Validate refresh token, verify GitHub token, re-issue access."""
+    refresh_id = request.cookies.get(REFRESH_COOKIE_NAME)
+    if not refresh_id:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail='Not authenticated',
         )
 
-    try:
-        payload = decode_token(access_token)
-    except jwt.ExpiredSignatureError:
+    user_id = await validate_refresh_token(refresh_id, redis_client)
+    if user_id is None:
         clear_access_cookie(response)
+        clear_refresh_cookie(response)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail='Token expired',
-        )
-    except jwt.InvalidTokenError:
-        clear_access_cookie(response)
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail='Invalid token',
+            detail='Invalid or expired refresh token',
         )
 
-    set_access_cookie(payload['sub'], response)
+    user = await user_repo.get_by_id(user_id)
+    if not user:
+        await revoke_refresh_token(refresh_id, redis_client)
+        clear_access_cookie(response)
+        clear_refresh_cookie(response)
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail='User not found',
+        )
+
+    # Validate the stored GitHub token (cached in Redis)
+    if user.encrypted_github_token:
+        github_token = decrypt_token(user.encrypted_github_token)
+        if github_token:
+            is_valid = await gh_service.validate_token(
+                user.id, github_token
+            )
+            if not is_valid:
+                await revoke_refresh_token(refresh_id, redis_client)
+                clear_access_cookie(response)
+                clear_refresh_cookie(response)
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail='GitHub token revoked',
+                )
+
+    set_access_cookie(str(user.github_id), response)
     return DetailSchema(detail='Token refreshed')
 
 
 @router.get('/logout', response_model=DetailSchema)
-def logout(response: Response):
+async def logout(
+    request: Request,
+    response: Response,
+    redis_client: RedisDp,
+):
+    refresh_id = request.cookies.get(REFRESH_COOKIE_NAME)
+    if refresh_id:
+        await revoke_refresh_token(refresh_id, redis_client)
+
     clear_access_cookie(response)
+    clear_refresh_cookie(response)
     return DetailSchema(detail='Logged out')

--- a/backend/app/presentation/api/oauth.py
+++ b/backend/app/presentation/api/oauth.py
@@ -1,9 +1,7 @@
-import jwt
 from fastapi import APIRouter, HTTPException, Request, Response, status
 from fastapi.responses import RedirectResponse
 from fastapi_sso.sso.github import GithubSSO
 
-from app.application.services.github_service import GitHubService
 from app.application.use_cases.user_registration import (
     UserRegistrationUseCase,
 )

--- a/backend/app/presentation/api/oauth.py
+++ b/backend/app/presentation/api/oauth.py
@@ -1,19 +1,20 @@
-from fastapi import APIRouter, HTTPException, Request, Response, status
+from fastapi import APIRouter, HTTPException, Request, Response
 from fastapi.responses import RedirectResponse
 from fastapi_sso.sso.github import GithubSSO
 
+from app.application.use_cases.refresh_token import (
+    RefreshTokenUseCase,
+)
 from app.application.use_cases.user_registration import (
     UserRegistrationUseCase,
 )
 from app.config.settings import REFRESH_COOKIE_NAME, envs
-from app.core.crypto import decrypt_token
 from app.core.tokens import (
     clear_access_cookie,
     clear_refresh_cookie,
     create_refresh_token,
     revoke_refresh_token,
     set_access_cookie,
-    validate_refresh_token,
 )
 from app.presentation.dependencies import (
     GitHubServiceDp,
@@ -63,9 +64,7 @@ async def auth_callback(
     # Check org membership with the fresh GitHub token
     is_org_member = False
     if github_token and envs.DISCORD_REPORTS_ORGANIZATION:
-        is_org_member = await gh_service.check_org_membership(
-            0, github_token  # user_id=0 skips cache on first check
-        )
+        is_org_member = await gh_service.check_org_membership(github_token)
 
     use_case = UserRegistrationUseCase(user_repo)
     user_data = await use_case.execute(
@@ -98,48 +97,8 @@ async def refresh_token(
 ):
     """Validate refresh token, verify GitHub token, re-issue access."""
     refresh_id = request.cookies.get(REFRESH_COOKIE_NAME)
-    if not refresh_id:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail='Not authenticated',
-        )
-
-    user_id = await validate_refresh_token(refresh_id, redis_client)
-    if user_id is None:
-        clear_access_cookie(response)
-        clear_refresh_cookie(response)
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail='Invalid or expired refresh token',
-        )
-
-    user = await user_repo.get_by_id(user_id)
-    if not user:
-        await revoke_refresh_token(refresh_id, redis_client)
-        clear_access_cookie(response)
-        clear_refresh_cookie(response)
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail='User not found',
-        )
-
-    # Validate the stored GitHub token (cached in Redis)
-    if user.encrypted_github_token:
-        github_token = decrypt_token(user.encrypted_github_token)
-        if github_token:
-            is_valid = await gh_service.validate_token(
-                user.id, github_token
-            )
-            if not is_valid:
-                await revoke_refresh_token(refresh_id, redis_client)
-                clear_access_cookie(response)
-                clear_refresh_cookie(response)
-                raise HTTPException(
-                    status_code=status.HTTP_401_UNAUTHORIZED,
-                    detail='GitHub token revoked',
-                )
-
-    set_access_cookie(str(user.github_id), response)
+    use_case = RefreshTokenUseCase(user_repo, gh_service, redis_client)
+    await use_case.execute(refresh_id, response)
     return DetailSchema(detail='Token refreshed')
 
 

--- a/backend/app/presentation/api/reports.py
+++ b/backend/app/presentation/api/reports.py
@@ -18,8 +18,8 @@ from app.application.use_cases.quinzenal_reports.list_reports import (
 from app.application.use_cases.quinzenal_reports.submit_report import (
     SubmitReportUseCase,
 )
-from app.lib.types import SnowflakeID
 from app.core.crypto import decrypt_token
+from app.lib.types import SnowflakeID
 from app.presentation.dependencies import (
     CurrentUserDp,
     DiscordServiceDp,

--- a/backend/app/presentation/api/reports.py
+++ b/backend/app/presentation/api/reports.py
@@ -18,7 +18,6 @@ from app.application.use_cases.quinzenal_reports.list_reports import (
 from app.application.use_cases.quinzenal_reports.submit_report import (
     SubmitReportUseCase,
 )
-from app.core.crypto import decrypt_token
 from app.lib.types import SnowflakeID
 from app.presentation.dependencies import (
     CurrentUserDp,
@@ -97,21 +96,9 @@ async def submit_report(
     gh_service: GitHubServiceDp,
     user_repo: UserRepositoryDp,
 ):
-    # Re-check org membership at submit time (cached in Redis)
-    is_org_member = c_user.is_org_member
-    if is_org_member:
-        user = await user_repo.get_by_id(c_user.id)
-        if user and user.encrypted_github_token:
-            github_token = decrypt_token(user.encrypted_github_token)
-            if github_token:
-                is_org_member = await gh_service.check_org_membership(
-                    c_user.id, github_token
-                )
-
-    use_case = SubmitReportUseCase(report_repo, discord_service)
-    data = SubmitReportPayloadDTO(**payload.model_dump())
-    report = await use_case.execute(
-        c_user.id, c_user.username, day, data,
-        is_org_member=is_org_member,
+    use_case = SubmitReportUseCase(
+        report_repo, discord_service, gh_service, user_repo,
     )
+    data = SubmitReportPayloadDTO(**payload.model_dump())
+    report = await use_case.execute(c_user.id, c_user.username, day, data)
     return SubmitReportResponse.model_validate(report.model_dump())

--- a/backend/app/presentation/api/reports.py
+++ b/backend/app/presentation/api/reports.py
@@ -19,10 +19,13 @@ from app.application.use_cases.quinzenal_reports.submit_report import (
     SubmitReportUseCase,
 )
 from app.lib.types import SnowflakeID
+from app.core.crypto import decrypt_token
 from app.presentation.dependencies import (
     CurrentUserDp,
     DiscordServiceDp,
+    GitHubServiceDp,
     QuinzenalReportRepositoryDp,
+    UserRepositoryDp,
 )
 from app.presentation.schemas import DetailSchema
 from app.presentation.schemas.quinzenal_report import (
@@ -91,8 +94,24 @@ async def submit_report(
     c_user: CurrentUserDp,
     report_repo: QuinzenalReportRepositoryDp,
     discord_service: DiscordServiceDp,
+    gh_service: GitHubServiceDp,
+    user_repo: UserRepositoryDp,
 ):
+    # Re-check org membership at submit time (cached in Redis)
+    is_org_member = c_user.is_org_member
+    if is_org_member:
+        user = await user_repo.get_by_id(c_user.id)
+        if user and user.encrypted_github_token:
+            github_token = decrypt_token(user.encrypted_github_token)
+            if github_token:
+                is_org_member = await gh_service.check_org_membership(
+                    c_user.id, github_token
+                )
+
     use_case = SubmitReportUseCase(report_repo, discord_service)
     data = SubmitReportPayloadDTO(**payload.model_dump())
-    report = await use_case.execute(c_user.id, c_user.username, day, data)
+    report = await use_case.execute(
+        c_user.id, c_user.username, day, data,
+        is_org_member=is_org_member,
+    )
     return SubmitReportResponse.model_validate(report.model_dump())

--- a/backend/app/presentation/dependencies.py
+++ b/backend/app/presentation/dependencies.py
@@ -1,13 +1,16 @@
 from typing import Annotated
 
+import redis.asyncio as aioredis
 from fastapi import Depends, Security
 from fastapi.security import APIKeyCookie
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.application.dto.user import UserDTO
 from app.application.services.discord_service import DiscordService
+from app.application.services.github_service import GitHubService
 from app.application.use_cases.get_current_user import GetCurrentUserUseCase
 from app.config.db import get_session
+from app.config.redis import get_redis
 from app.config.settings import ACCESS_COOKIE_NAME, envs
 from app.domain.repositories.application_repository import (
     ApplicationRepository,
@@ -142,6 +145,20 @@ def get_discord_feedback_service():
 
 DiscordFeedbackServiceDp = Annotated[
     DiscordService, Depends(get_discord_feedback_service)
+]
+
+
+RedisDp = Annotated[aioredis.Redis, Depends(get_redis)]
+
+
+async def get_github_service(
+    redis_client: RedisDp,
+) -> GitHubService:
+    return GitHubService(redis_client)
+
+
+GitHubServiceDp = Annotated[
+    GitHubService, Depends(get_github_service)
 ]
 
 

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -5,16 +5,21 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      redis:
+        condition: service_healthy
     environment:
       - ENVIRONMENT=DEV
       - CORS_ORIGINS=["http://127.0.0.1:8080"]
       - DATABASE_URL=postgresql+asyncpg://postgres:postgres@db:5432/applika
+      - REDIS_URL=redis://redis:6379/0
       - GITHUB_CLIENT_ID=<your-client-id>
       - GITHUB_CLIENT_SECRET=<your-client-secret>
       - GITHUB_REDIRECT_URI=http://127.0.0.1:8000/api/auth/github/callback
+      - GITHUB_TOKEN_ENCRYPTION_KEY=<your-fernet-key>
       - LOGIN_REDIRECT_URI=http://127.0.0.1:3000/dashboard
       - DISCORD_REPORTS_WEBHOOK=<your-webhook-url>
       - DISCORD_FEEDBACK_WEBHOOK=<your-webhook-url>
+      - DISCORD_REPORTS_ORGANIZATION=<your-github-org>
     ports:
       - "8000:8000"
     entrypoint: ["sh", "-c", "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8000"]
@@ -38,5 +43,20 @@ services:
       timeout: 5s
       retries: 5
 
+  redis:
+    image: redis:7-alpine
+    container_name: applika.dev-redis
+    ports:
+      - "6379:6379"
+    restart: unless-stopped
+    volumes:
+      - applika_redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
 volumes:
   applika_db_data:
+  applika_redis_data:

--- a/backend/migrations/versions/d5e6f7a8b9c0_add_github_token_and_org_member.py
+++ b/backend/migrations/versions/d5e6f7a8b9c0_add_github_token_and_org_member.py
@@ -1,0 +1,41 @@
+"""add encrypted_github_token and is_org_member to users
+
+Revision ID: d5e6f7a8b9c0
+Revises: c4f8a1b2d3e5
+Create Date: 2026-04-10 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'd5e6f7a8b9c0'
+down_revision: Union[str, Sequence[str], None] = 'c4f8a1b2d3e5'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        'users',
+        sa.Column('encrypted_github_token', sa.Text(), nullable=True),
+    )
+    op.add_column(
+        'users',
+        sa.Column(
+            'is_org_member',
+            sa.Boolean(),
+            server_default='false',
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('users', 'is_org_member')
+    op.drop_column('users', 'encrypted_github_token')

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -14,6 +14,8 @@ dependencies = [
     "pydantic-settings>=2.0",
     "email-validator>=2.3.0",
     "snowflake-id>=1.0.2",
+    "redis[hiredis]>=7.4.0",
+    "cryptography>=46.0.7",
 ]
 
 [dependency-groups]

--- a/backend/tests/integration/test_date_validations.py
+++ b/backend/tests/integration/test_date_validations.py
@@ -202,20 +202,6 @@ async def test_create_step_after_application_date_succeeds(
 
 
 @freeze_time(FROZEN_NOW, ignore=['snowflake'])
-async def test_create_step_with_future_date_returns_422(
-    async_client: AsyncClient, db_session: AsyncSession
-):
-    await _seed_steps_and_app(db_session, application_date=date(2026, 4, 1))
-
-    payload = {'step_id': 1, 'step_date': ONE_DAY_PAST_MAX.isoformat()}
-    response = await async_client.post(
-        '/applications/1/steps', json=payload
-    )
-
-    assert response.status_code == 422, msg(422, response.status_code)
-
-
-@freeze_time(FROZEN_NOW, ignore=['snowflake'])
 async def test_create_step_earlier_than_previous_step_returns_422(
     async_client: AsyncClient, db_session: AsyncSession
 ):

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -53,11 +53,13 @@ source = { virtual = "." }
 dependencies = [
     { name = "alembic" },
     { name = "asyncpg" },
+    { name = "cryptography" },
     { name = "email-validator" },
     { name = "fastapi", extra = ["standard"] },
     { name = "fastapi-sso" },
     { name = "pydantic", extra = ["email"] },
     { name = "pydantic-settings" },
+    { name = "redis", extra = ["hiredis"] },
     { name = "snowflake-id" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "uvicorn", extra = ["standard"] },
@@ -81,11 +83,13 @@ dev = [
 requires-dist = [
     { name = "alembic", specifier = ">=1.14" },
     { name = "asyncpg", specifier = ">=0.30" },
+    { name = "cryptography", specifier = ">=46.0.7" },
     { name = "email-validator", specifier = ">=2.3.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115" },
     { name = "fastapi-sso", specifier = ">=0.18.0" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.0" },
     { name = "pydantic-settings", specifier = ">=2.0" },
+    { name = "redis", extras = ["hiredis"], specifier = ">=7.4.0" },
     { name = "snowflake-id", specifier = ">=1.0.2" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34" },
@@ -148,6 +152,39 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
 ]
 
 [[package]]
@@ -233,6 +270,59 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/96/38086d58a181aac86d503dfa9c47eb20715a79c3e3acbdf786e92e5c09a8/coverage-7.13.4-cp314-cp314t-win_amd64.whl", hash = "sha256:4c7d3cc01e7350f2f0f6f7036caaf5673fb56b6998889ccfe9e1c1fe75a9c932", size = 224148, upload-time = "2026-02-09T12:58:58.645Z" },
     { url = "https://files.pythonhosted.org/packages/ce/72/8d10abd3740a0beb98c305e0c3faf454366221c0f37a8bcf8f60020bb65a/coverage-7.13.4-cp314-cp314t-win_arm64.whl", hash = "sha256:23e3f687cf945070d1c90f85db66d11e3025665d8dafa831301a0e0038f3db9b", size = 222172, upload-time = "2026-02-09T12:59:00.396Z" },
     { url = "https://files.pythonhosted.org/packages/0d/4a/331fe2caf6799d591109bb9c08083080f6de90a823695d412a935622abb2/coverage-7.13.4-py3-none-any.whl", hash = "sha256:1af1641e57cf7ba1bd67d677c9abdbcd6cc2ab7da3bca7fa1e2b7e50e65f2ad0", size = 211242, upload-time = "2026-02-09T12:59:02.032Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "46.0.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/93/ac8f3d5ff04d54bc814e961a43ae5b0b146154c89c61b47bb07557679b18/cryptography-46.0.7.tar.gz", hash = "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5", size = 750652, upload-time = "2026-04-08T01:57:54.692Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/5d/4a8f770695d73be252331e60e526291e3df0c9b27556a90a6b47bccca4c2/cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:ea42cbe97209df307fdc3b155f1b6fa2577c0defa8f1f7d3be7d31d189108ad4", size = 7179869, upload-time = "2026-04-08T01:56:17.157Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/45/6d80dc379b0bbc1f9d1e429f42e4cb9e1d319c7a8201beffd967c516ea01/cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325", size = 4275492, upload-time = "2026-04-08T01:56:19.36Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/9a/1765afe9f572e239c3469f2cb429f3ba7b31878c893b246b4b2994ffe2fe/cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308", size = 4426670, upload-time = "2026-04-08T01:56:21.415Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/3e/af9246aaf23cd4ee060699adab1e47ced3f5f7e7a8ffdd339f817b446462/cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77", size = 4280275, upload-time = "2026-04-08T01:56:23.539Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/54/6bbbfc5efe86f9d71041827b793c24811a017c6ac0fd12883e4caa86b8ed/cryptography-46.0.7-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1", size = 4928402, upload-time = "2026-04-08T01:56:25.624Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/cf/054b9d8220f81509939599c8bdbc0c408dbd2bdd41688616a20731371fe0/cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef", size = 4459985, upload-time = "2026-04-08T01:56:27.309Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/46/4e4e9c6040fb01c7467d47217d2f882daddeb8828f7df800cb806d8a2288/cryptography-46.0.7-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de", size = 3990652, upload-time = "2026-04-08T01:56:29.095Z" },
+    { url = "https://files.pythonhosted.org/packages/36/5f/313586c3be5a2fbe87e4c9a254207b860155a8e1f3cca99f9910008e7d08/cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83", size = 4279805, upload-time = "2026-04-08T01:56:30.928Z" },
+    { url = "https://files.pythonhosted.org/packages/69/33/60dfc4595f334a2082749673386a4d05e4f0cf4df8248e63b2c3437585f2/cryptography-46.0.7-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb", size = 4892883, upload-time = "2026-04-08T01:56:32.614Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/0b/333ddab4270c4f5b972f980adef4faa66951a4aaf646ca067af597f15563/cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b", size = 4459756, upload-time = "2026-04-08T01:56:34.306Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/14/633913398b43b75f1234834170947957c6b623d1701ffc7a9600da907e89/cryptography-46.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85", size = 4410244, upload-time = "2026-04-08T01:56:35.977Z" },
+    { url = "https://files.pythonhosted.org/packages/10/f2/19ceb3b3dc14009373432af0c13f46aa08e3ce334ec6eff13492e1812ccd/cryptography-46.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e", size = 4674868, upload-time = "2026-04-08T01:56:38.034Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/bb/a5c213c19ee94b15dfccc48f363738633a493812687f5567addbcbba9f6f/cryptography-46.0.7-cp311-abi3-win32.whl", hash = "sha256:d23c8ca48e44ee015cd0a54aeccdf9f09004eba9fc96f38c911011d9ff1bd457", size = 3026504, upload-time = "2026-04-08T01:56:39.666Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/02/7788f9fefa1d060ca68717c3901ae7fffa21ee087a90b7f23c7a603c32ae/cryptography-46.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:397655da831414d165029da9bc483bed2fe0e75dde6a1523ec2fe63f3c46046b", size = 3488363, upload-time = "2026-04-08T01:56:41.893Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/56/15619b210e689c5403bb0540e4cb7dbf11a6bf42e483b7644e471a2812b3/cryptography-46.0.7-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:d151173275e1728cf7839aaa80c34fe550c04ddb27b34f48c232193df8db5842", size = 7119671, upload-time = "2026-04-08T01:56:44Z" },
+    { url = "https://files.pythonhosted.org/packages/74/66/e3ce040721b0b5599e175ba91ab08884c75928fbeb74597dd10ef13505d2/cryptography-46.0.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:db0f493b9181c7820c8134437eb8b0b4792085d37dbb24da050476ccb664e59c", size = 4268551, upload-time = "2026-04-08T01:56:46.071Z" },
+    { url = "https://files.pythonhosted.org/packages/03/11/5e395f961d6868269835dee1bafec6a1ac176505a167f68b7d8818431068/cryptography-46.0.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ebd6daf519b9f189f85c479427bbd6e9c9037862cf8fe89ee35503bd209ed902", size = 4408887, upload-time = "2026-04-08T01:56:47.718Z" },
+    { url = "https://files.pythonhosted.org/packages/40/53/8ed1cf4c3b9c8e611e7122fb56f1c32d09e1fff0f1d77e78d9ff7c82653e/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b7b412817be92117ec5ed95f880defe9cf18a832e8cafacf0a22337dc1981b4d", size = 4271354, upload-time = "2026-04-08T01:56:49.312Z" },
+    { url = "https://files.pythonhosted.org/packages/50/46/cf71e26025c2e767c5609162c866a78e8a2915bbcfa408b7ca495c6140c4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:fbfd0e5f273877695cb93baf14b185f4878128b250cc9f8e617ea0c025dfb022", size = 4905845, upload-time = "2026-04-08T01:56:50.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ea/01276740375bac6249d0a971ebdf6b4dc9ead0ee0a34ef3b5a88c1a9b0d4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:ffca7aa1d00cf7d6469b988c581598f2259e46215e0140af408966a24cf086ce", size = 4444641, upload-time = "2026-04-08T01:56:52.882Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/4c/7d258f169ae71230f25d9f3d06caabcff8c3baf0978e2b7d65e0acac3827/cryptography-46.0.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:60627cf07e0d9274338521205899337c5d18249db56865f943cbe753aa96f40f", size = 3967749, upload-time = "2026-04-08T01:56:54.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/2a/2ea0767cad19e71b3530e4cad9605d0b5e338b6a1e72c37c9c1ceb86c333/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:80406c3065e2c55d7f49a9550fe0c49b3f12e5bfff5dedb727e319e1afb9bf99", size = 4270942, upload-time = "2026-04-08T01:56:56.416Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3d/fe14df95a83319af25717677e956567a105bb6ab25641acaa093db79975d/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:c5b1ccd1239f48b7151a65bc6dd54bcfcc15e028c8ac126d3fada09db0e07ef1", size = 4871079, upload-time = "2026-04-08T01:56:58.31Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/59/4a479e0f36f8f378d397f4eab4c850b4ffb79a2f0d58704b8fa0703ddc11/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d5f7520159cd9c2154eb61eb67548ca05c5774d39e9c2c4339fd793fe7d097b2", size = 4443999, upload-time = "2026-04-08T01:57:00.508Z" },
+    { url = "https://files.pythonhosted.org/packages/28/17/b59a741645822ec6d04732b43c5d35e4ef58be7bfa84a81e5ae6f05a1d33/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fcd8eac50d9138c1d7fc53a653ba60a2bee81a505f9f8850b6b2888555a45d0e", size = 4399191, upload-time = "2026-04-08T01:57:02.654Z" },
+    { url = "https://files.pythonhosted.org/packages/59/6a/bb2e166d6d0e0955f1e9ff70f10ec4b2824c9cfcdb4da772c7dd69cc7d80/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:65814c60f8cc400c63131584e3e1fad01235edba2614b61fbfbfa954082db0ee", size = 4655782, upload-time = "2026-04-08T01:57:04.592Z" },
+    { url = "https://files.pythonhosted.org/packages/95/b6/3da51d48415bcb63b00dc17c2eff3a651b7c4fed484308d0f19b30e8cb2c/cryptography-46.0.7-cp314-cp314t-win32.whl", hash = "sha256:fdd1736fed309b4300346f88f74cd120c27c56852c3838cab416e7a166f67298", size = 3002227, upload-time = "2026-04-08T01:57:06.91Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a8/9f0e4ed57ec9cebe506e58db11ae472972ecb0c659e4d52bbaee80ca340a/cryptography-46.0.7-cp314-cp314t-win_amd64.whl", hash = "sha256:e06acf3c99be55aa3b516397fe42f5855597f430add9c17fa46bf2e0fb34c9bb", size = 3475332, upload-time = "2026-04-08T01:57:08.807Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/7f/cd42fc3614386bc0c12f0cb3c4ae1fc2bbca5c9662dfed031514911d513d/cryptography-46.0.7-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:462ad5cb1c148a22b2e3bcc5ad52504dff325d17daf5df8d88c17dda1f75f2a4", size = 7165618, upload-time = "2026-04-08T01:57:10.645Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/d0/36a49f0262d2319139d2829f773f1b97ef8aef7f97e6e5bd21455e5a8fb5/cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7", size = 4270628, upload-time = "2026-04-08T01:57:12.885Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/6c/1a42450f464dda6ffbe578a911f773e54dd48c10f9895a23a7e88b3e7db5/cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832", size = 4415405, upload-time = "2026-04-08T01:57:14.923Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/92/4ed714dbe93a066dc1f4b4581a464d2d7dbec9046f7c8b7016f5286329e2/cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163", size = 4272715, upload-time = "2026-04-08T01:57:16.638Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e6/a26b84096eddd51494bba19111f8fffe976f6a09f132706f8f1bf03f51f7/cryptography-46.0.7-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2", size = 4918400, upload-time = "2026-04-08T01:57:19.021Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/08/ffd537b605568a148543ac3c2b239708ae0bd635064bab41359252ef88ed/cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067", size = 4450634, upload-time = "2026-04-08T01:57:21.185Z" },
+    { url = "https://files.pythonhosted.org/packages/16/01/0cd51dd86ab5b9befe0d031e276510491976c3a80e9f6e31810cce46c4ad/cryptography-46.0.7-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0", size = 3985233, upload-time = "2026-04-08T01:57:22.862Z" },
+    { url = "https://files.pythonhosted.org/packages/92/49/819d6ed3a7d9349c2939f81b500a738cb733ab62fbecdbc1e38e83d45e12/cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba", size = 4271955, upload-time = "2026-04-08T01:57:24.814Z" },
+    { url = "https://files.pythonhosted.org/packages/80/07/ad9b3c56ebb95ed2473d46df0847357e01583f4c52a85754d1a55e29e4d0/cryptography-46.0.7-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006", size = 4879888, upload-time = "2026-04-08T01:57:26.88Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c7/201d3d58f30c4c2bdbe9b03844c291feb77c20511cc3586daf7edc12a47b/cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0", size = 4449961, upload-time = "2026-04-08T01:57:29.068Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ef/649750cbf96f3033c3c976e112265c33906f8e462291a33d77f90356548c/cryptography-46.0.7-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85", size = 4401696, upload-time = "2026-04-08T01:57:31.029Z" },
+    { url = "https://files.pythonhosted.org/packages/41/52/a8908dcb1a389a459a29008c29966c1d552588d4ae6d43f3a1a4512e0ebe/cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e", size = 4664256, upload-time = "2026-04-08T01:57:33.144Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/fa/f0ab06238e899cc3fb332623f337a7364f36f4bb3f2534c2bb95a35b132c/cryptography-46.0.7-cp38-abi3-win32.whl", hash = "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246", size = 3013001, upload-time = "2026-04-08T01:57:34.933Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/f1/00ce3bde3ca542d1acd8f8cfa38e446840945aa6363f9b74746394b14127/cryptography-46.0.7-cp38-abi3-win_amd64.whl", hash = "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3", size = 3472985, upload-time = "2026-04-08T01:57:36.714Z" },
 ]
 
 [[package]]
@@ -439,6 +529,40 @@ wheels = [
 ]
 
 [[package]]
+name = "hiredis"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/97/d6/9bef6dc3052c168c93fbf7e6c0f2b12c45f0f741a2d30fd919096774343a/hiredis-3.3.1.tar.gz", hash = "sha256:da6f0302360e99d32bc2869772692797ebadd536e1b826d0103c72ba49d38698", size = 89101, upload-time = "2026-03-16T15:21:08.092Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/72/0450d6b449da58120c5497346eb707738f8f67b9e60c28a8ef90133fc81f/hiredis-3.3.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:439f9a5cc8f9519ce208a24cdebfa0440fef26aa682a40ba2c92acb10a53f5e0", size = 82112, upload-time = "2026-03-16T15:20:02.865Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c0/0be33a29bcd463e6cbb0282515dd4d0cdfe33c30c7afc6d4d8c460e23266/hiredis-3.3.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3724f0e58c6ff76fd683429945491de71324ab1bc0ad943a8d68cb0932d24075", size = 46238, upload-time = "2026-03-16T15:20:03.896Z" },
+    { url = "https://files.pythonhosted.org/packages/62/f2/f999854bfaf3bcbee0f797f24706c182ecfaca825f6a582f6281a6aa97e0/hiredis-3.3.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:29fe35e3c6fe03204e75c86514f452591957a1e06b05d86e10d795455b71c355", size = 41891, upload-time = "2026-03-16T15:20:04.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c8/cd9ab90fec3a301d864d8ab6167aea387add8e2287969d89cbcd45d6b0e0/hiredis-3.3.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d42f3a13290f89191568fc113d95a3d2c8759cdd8c3672f021d8b7436f909e75", size = 170485, upload-time = "2026-03-16T15:20:06.284Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/9a/1ddf9ea236a292963146cbaf6722abeb9d503ca47d821267bb8b3b81c4f7/hiredis-3.3.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2afc675b831f7552da41116fffffca4340f387dc03f56d6ec0c7895ab0b59a10", size = 182030, upload-time = "2026-03-16T15:20:07.857Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/b8/e070a1dbf8a1bbb8814baa0b00836fbe3f10c7af8e11f942cc739c64e062/hiredis-3.3.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4106201cd052d9eabe3cb7b5a24b0fe37307792bda4fcb3cf6ddd72f697828e8", size = 180543, upload-time = "2026-03-16T15:20:09.096Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bb/b5f4f98e44626e2446cd8a52ce6cb1fc1c99786b6e2db3bf09cea97b90cd/hiredis-3.3.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8887bf0f31e4b550bd988c8863b527b6587d200653e9375cd91eea2b944b7424", size = 172356, upload-time = "2026-03-16T15:20:10.245Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/93/73a77b54ba94e82f76d02563c588d8a062513062675f483a033a43015f2c/hiredis-3.3.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1ac7697365dbe45109273b34227fee6826b276ead9a4a007e0877e1d3f0fcf21", size = 166433, upload-time = "2026-03-16T15:20:11.789Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c2/1b2dcbe5dc53a46a8cb05bed67d190a7e30bad2ad1f727ebe154dfeededd/hiredis-3.3.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2b6da6e07359107c653a809b3cff2d9ccaeedbafe33c6f16434aef6f53ce4a2b", size = 177220, upload-time = "2026-03-16T15:20:12.991Z" },
+    { url = "https://files.pythonhosted.org/packages/02/09/f4314cf096552568b5ea785ceb60c424771f4d35a76c410ad39d258f74bc/hiredis-3.3.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:ce334915f5d31048f76a42c607bf26687cf045eb1bc852b7340f09729c6a64fc", size = 170475, upload-time = "2026-03-16T15:20:14.519Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/2e/3f56e438efc8fc27ed4a3dbad58c0280061466473ec35d8f86c90c841a84/hiredis-3.3.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ee11fd431f83d8a5b29d370b9d79a814d3218d30113bdcd44657e9bdf715fc92", size = 167913, upload-time = "2026-03-16T15:20:15.672Z" },
+    { url = "https://files.pythonhosted.org/packages/56/34/053e5ee91d6dc478faac661996d1fd4886c5acb7a1b5ac30e7d3c794bb51/hiredis-3.3.1-cp314-cp314-win32.whl", hash = "sha256:e0356561b4a97c83b9ee3de657a41b8d1a1781226853adaf47b550bb988fda6f", size = 21167, upload-time = "2026-03-16T15:20:17.013Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/33/06776c641d17881a9031e337e81b3b934c38c2adbb83c85062d6b5f83b72/hiredis-3.3.1-cp314-cp314-win_amd64.whl", hash = "sha256:80aba5f85d6227faee628ae28d1c3b69c661806a0636548ac56c68782606454f", size = 23000, upload-time = "2026-03-16T15:20:17.966Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/5a/94f9a505b2ff5376d4a05fb279b69d89bafa7219dd33f6944026e3e56f80/hiredis-3.3.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:907f7b5501a534030738f0f27459a612d2266fd0507b007bb8f3e6de08167920", size = 83039, upload-time = "2026-03-16T15:20:19.316Z" },
+    { url = "https://files.pythonhosted.org/packages/93/ae/d3752a8f03a1fca43d402389d2a2d234d3db54c4d1f07f26c1041ca3c5de/hiredis-3.3.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:de94b409f49eb6a588ebdd5872e826caec417cd77c17af0fb94f2128427f1a2a", size = 46703, upload-time = "2026-03-16T15:20:20.401Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/76/e32c868a2fa23cd82bacaffd38649d938173244a0e717ec1c0c76874dbdd/hiredis-3.3.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:79cd03e7ff550c17758a7520bf437c156d3d4c8bb74214deeafa69cda49c85a4", size = 42379, upload-time = "2026-03-16T15:20:21.705Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/f6/d687d36a74ce6cf448826cf2e8edfc1eb37cc965308f74eb696aa97c69df/hiredis-3.3.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6ffa7ba2e2da1f806f3181b9730b3e87ba9dbfec884806725d4584055ba3faa6", size = 180311, upload-time = "2026-03-16T15:20:23.037Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ac/f520dc0066a62a15aa920c7dd0a2028c213f4862d5f901409ae92ee5d785/hiredis-3.3.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ee37fe8cf081b72dea72f96a0ee604f492ec02252eb77dc26ff6eec3f997b580", size = 190488, upload-time = "2026-03-16T15:20:24.357Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/f5/ae10fff82d0f291e90c41bf10a5d6543a96aae00cccede01bf2b6f7e178d/hiredis-3.3.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9bfdeff778d3f7ff449ca5922ab773899e7d31e26a576028b06a5e9cf0ed8c34", size = 189210, upload-time = "2026-03-16T15:20:25.51Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/8f/5be4344e542aa8d349a03d05486c59d9ca26f69c749d11e114bf34b84d50/hiredis-3.3.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:027ce4fabfeff5af5b9869d5524770877f9061d118bc36b85703ae3faf5aad8e", size = 180971, upload-time = "2026-03-16T15:20:26.631Z" },
+    { url = "https://files.pythonhosted.org/packages/41/a2/29e230226ec2a31f13f8a832fbafe366e263f3b090553ebe49bb4581a7bd/hiredis-3.3.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:dcea8c3f53674ae68e44b12e853b844a1d315250ca6677b11ec0c06aff85e86c", size = 175314, upload-time = "2026-03-16T15:20:27.848Z" },
+    { url = "https://files.pythonhosted.org/packages/89/2e/bf241707ad86b9f3ebfbc7ab89e19d5ec243ff92ca77644a383622e8740b/hiredis-3.3.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0b5ff2f643f4b452b0597b7fe6aa35d398cb31d8806801acfafb1558610ea2aa", size = 185652, upload-time = "2026-03-16T15:20:29.364Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c1/b39170d8bcccd01febd45af4ac6b43ff38e134a868e2ec167a82a036fb35/hiredis-3.3.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:3586c8a5f56d34b9dddaaa9e76905f31933cac267251006adf86ec0eef7d0400", size = 179033, upload-time = "2026-03-16T15:20:30.549Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/3a/4fe39a169115434f911abff08ff485b9b6201c168500e112b3f6a8110c0a/hiredis-3.3.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a110d19881ca78a88583d3b07231e7c6864864f5f1f3491b638863ea45fa8708", size = 176126, upload-time = "2026-03-16T15:20:31.958Z" },
+    { url = "https://files.pythonhosted.org/packages/44/99/c1d0b0bc4f9e9150e24beb0dca2e186e32d5e749d0022e0d26453749ed51/hiredis-3.3.1-cp314-cp314t-win32.whl", hash = "sha256:98fd5b39410e9d69e10e90d0330e35650becaa5dd2548f509b9598f1f3c6124d", size = 22028, upload-time = "2026-03-16T15:20:33.33Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d6/191e6741addc97bcf5e755661f8c82f0fd0aa35f07ece56e858da689b57e/hiredis-3.3.1-cp314-cp314t-win_amd64.whl", hash = "sha256:ab1f646ff531d70bfd25f01e60708dfa3d105eb458b7dedd9fe9a443039fd809", size = 23811, upload-time = "2026-03-16T15:20:34.292Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -632,6 +756,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/11/e0/abfd2a0d2efe47670df87f3e3a0e2edda42f055053c85361f19c0e2c1ca8/pycodestyle-2.14.0.tar.gz", hash = "sha256:c4b5b517d278089ff9d0abdec919cd97262a3367449ea1c8b49b91529167b783", size = 39472, upload-time = "2025-06-20T18:49:48.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/27/a58ddaf8c588a3ef080db9d0b7e0b97215cee3a45df74f3a94dbbf5c893a/pycodestyle-2.14.0-py2.py3-none-any.whl", hash = "sha256:dd6bf7cb4ee77f8e016f9c8e74a35ddd9f67e1d5fd4184d86c3b98e07099f42d", size = 31594, upload-time = "2025-06-20T18:49:47.491Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
 ]
 
 [[package]]
@@ -857,6 +990,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "redis"
+version = "7.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/7f/3759b1d0d72b7c92f0d70ffd9dc962b7b7b5ee74e135f9d7d8ab06b8a318/redis-7.4.0.tar.gz", hash = "sha256:64a6ea7bf567ad43c964d2c30d82853f8df927c5c9017766c55a1d1ed95d18ad", size = 4943913, upload-time = "2026-03-24T09:14:37.53Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/3a/95deec7db1eb53979973ebd156f3369a72732208d1391cd2e5d127062a32/redis-7.4.0-py3-none-any.whl", hash = "sha256:a9c74a5c893a5ef8455a5adb793a31bb70feb821c86eccb62eebef5a19c429ec", size = 409772, upload-time = "2026-03-24T09:14:35.968Z" },
+]
+
+[package.optional-dependencies]
+hiredis = [
+    { name = "hiredis" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
#32 Add GitHub organization membership verification and secure token infrastructure. During OAuth login, the backend now encrypts and stores the user's GitHub token, checks membership in a configured GitHub org, and gates the Discord report webhook behind org membership. Introduces a Redis-backed refresh token system to replace raw access-token-only auth.

## Checklist
- [ ] Self-review completed
- [ ] CI passing
- [ ] Ready to merge
