### PR TITLE
fix(cli): set default api base url to applika.dev

### DIFF
--- a/cli/src/session.py
+++ b/cli/src/session.py
@@ -6,7 +6,7 @@ from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
-DEFAULT_API_BASE_URL = 'http://127.0.0.1:8000/api'
+DEFAULT_API_BASE_URL = 'https://applika.dev/api'
 
 
 @dataclass


### PR DESCRIPTION
## Summary

- Changes the CLI's default `DEFAULT_API_BASE_URL` from `http://127.0.0.1:8000/api` (localhost) to `https://applika.dev/api`
- Users who install the CLI no longer need to manually configure the API URL

## Test plan

- [ ] Install the CLI and verify it points to `https://applika.dev/api` by default without any configuration
- [ ] Verify `APPLIKA_API_BASE_URL` env var and `--api-base-url` flag still override the default