### PR TITLE
Add application step commands and finalize validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,34 +23,48 @@ root/
 
 ## CLI
 
-Install the CLI command from the repo:
+Install the published CLI from PyPI. The package page has the current install
+and usage docs:
+
+- [applika-cli on PyPI](https://pypi.org/project/applika-cli/)
 
 ```bash
-cd cli
-make install
+uv tool install applika-cli
+# or
+pipx install applika-cli
 ```
 
-This uses `uv tool install --force .` and works the same on Linux, macOS, and Windows.
-If `make` is not available on Windows, run the underlying command directly:
+This installs the global `applika` command:
 
 ```bash
-cd cli
-uv tool install --force .
+applika --help
+applika --version
+applika version
 ```
 
-For local CLI development:
+For local CLI development from this repository:
 
 ```bash
 cd cli
-make install-dev
+uv sync
+uv run applika --help
+```
+
+If you want the global `applika` command to point at your local checkout while
+you develop, install it in editable mode:
+
+```bash
+cd cli
+uv tool install --force --editable .
 ```
 
 Useful commands:
 
 ```bash
 cd cli
-make help    # Show applika CLI help
 make test    # Run CLI tests
+make format  # Format CLI code
+make lint    # Lint CLI code
 ```
 
 CLI commands:
@@ -72,6 +86,15 @@ applika applications -n \
   --platform "LinkedIn" \
   --mode active \
   --date 2026-05-08
+applika applications steps list 123
+applika applications steps add 123 \
+  --step "Initial Screen" \
+  --date 2026-05-11
+applika applications finalize 123 \
+  --step "Offer" \
+  --feedback "Accepted" \
+  --date 2026-05-18 \
+  --salary-offer 180000
 ```
 
 ## Quick Start (Docker Compose)

--- a/backend/app/application/use_cases/applications/finalize_application.py
+++ b/backend/app/application/use_cases/applications/finalize_application.py
@@ -23,6 +23,9 @@ from app.domain.repositories.step_definition_repository import (
     StepDefinitionRepository,
 )
 
+OFFER_STEP_NAME = 'offer'
+ACCEPTED_FEEDBACK_NAME = 'accepted'
+
 
 class FinalizeApplicationUseCase:
     def __init__(
@@ -88,6 +91,12 @@ class FinalizeApplicationUseCase:
         if not feedback:
             raise ResourceNotFound('Feedback not found')
 
+        self._validate_finalize_combination(
+            step_name=step.name,
+            feedback_name=feedback.name,
+            salary_offer=data.salary_offer,
+        )
+
         # Insert final step record
         application_step = ApplicationStepCreateDTO(
             user_id=user_id,
@@ -118,3 +127,37 @@ class FinalizeApplicationUseCase:
             },
         )
         return ApplicationDTO.model_validate(application)
+
+    @staticmethod
+    def _validate_finalize_combination(
+        *,
+        step_name: str,
+        feedback_name: str,
+        salary_offer: float | None,
+    ) -> None:
+        normalized_step = step_name.strip().lower()
+        normalized_feedback = feedback_name.strip().lower()
+
+        if (
+            normalized_feedback == ACCEPTED_FEEDBACK_NAME
+            and normalized_step != OFFER_STEP_NAME
+        ):
+            raise BusinessRuleViolation(
+                'Accepted feedback requires the Offer final step'
+            )
+
+        if (
+            normalized_step == OFFER_STEP_NAME
+            and normalized_feedback != ACCEPTED_FEEDBACK_NAME
+        ):
+            raise BusinessRuleViolation(
+                'Offer final step requires Accepted feedback'
+            )
+
+        if salary_offer is not None and (
+            normalized_step != OFFER_STEP_NAME
+            or normalized_feedback != ACCEPTED_FEEDBACK_NAME
+        ):
+            raise BusinessRuleViolation(
+                'salary_offer can only be set for Offer + Accepted'
+            )

--- a/backend/tests/integration/test_finalize.py
+++ b/backend/tests/integration/test_finalize.py
@@ -137,3 +137,61 @@ async def test_finalize_with_invalid_feedback_returns_404(
     )
 
     assert response.status_code == 404, msg(404, response.status_code)
+
+
+async def test_finalize_offer_requires_accepted_feedback(
+    async_client: AsyncClient, db_session: AsyncSession
+):
+    await _seed_finalize_data(db_session)
+
+    payload = {
+        'step_id': 2,  # Offer
+        'feedback_id': base_data()['fb_denied'].id,  # Denied
+        'finalize_date': '2025-12-15',
+    }
+    response = await async_client.post(
+        '/applications/1/finalize', json=payload
+    )
+
+    assert response.status_code == 422, msg(422, response.status_code)
+    assert response.json()['detail'] == 'Offer final step requires Accepted feedback'
+
+
+async def test_finalize_accepted_requires_offer_step(
+    async_client: AsyncClient, db_session: AsyncSession
+):
+    await _seed_finalize_data(db_session)
+
+    payload = {
+        'step_id': 3,  # Denied
+        'feedback_id': 2,  # Accepted
+        'finalize_date': '2025-12-15',
+    }
+    response = await async_client.post(
+        '/applications/1/finalize', json=payload
+    )
+
+    assert response.status_code == 422, msg(422, response.status_code)
+    assert response.json()['detail'] == 'Accepted feedback requires the Offer final step'
+
+
+async def test_finalize_salary_offer_requires_offer_and_accepted(
+    async_client: AsyncClient, db_session: AsyncSession
+):
+    await _seed_finalize_data(db_session)
+
+    payload = {
+        'step_id': 3,  # Denied
+        'feedback_id': base_data()['fb_denied'].id,  # Denied
+        'finalize_date': '2025-12-15',
+        'salary_offer': 95000.0,
+    }
+    response = await async_client.post(
+        '/applications/1/finalize', json=payload
+    )
+
+    assert response.status_code == 422, msg(422, response.status_code)
+    assert (
+        response.json()['detail']
+        == 'salary_offer can only be set for Offer + Accepted'
+    )

--- a/backend/tests/unit/test_finalize_application.py
+++ b/backend/tests/unit/test_finalize_application.py
@@ -1,4 +1,5 @@
 from unittest.mock import AsyncMock, MagicMock
+from types import SimpleNamespace
 
 import pytest
 
@@ -89,8 +90,12 @@ async def test_finalize_success():
     )
     app = make_application()
     uc.application_repo.get_by_id_and_user_id.return_value = app
-    uc.step_repo.get_by_id_strict_only.return_value = MagicMock(id=2)
-    uc.feedback_repo.get_by_id.return_value = MagicMock(id=3)
+    uc.step_repo.get_by_id_strict_only.return_value = SimpleNamespace(
+        id=2, name='Offer'
+    )
+    uc.feedback_repo.get_by_id.return_value = SimpleNamespace(
+        id=3, name='Accepted'
+    )
     uc.application_repo.update.return_value = app
 
     await uc.execute(
@@ -103,3 +108,69 @@ async def test_finalize_success():
     assert app.feedback_id == 3
     assert app.last_step_id == 2
     assert app.salary_offer == 90000.0
+
+
+async def test_finalize_offer_requires_accepted_feedback():
+    uc = FinalizeApplicationUseCase(
+        AsyncMock(), AsyncMock(), AsyncMock(), AsyncMock()
+    )
+    uc.application_repo.get_by_id_and_user_id.return_value = (
+        make_application()
+    )
+    uc.step_repo.get_by_id_strict_only.return_value = SimpleNamespace(
+        id=2, name='Offer'
+    )
+    uc.feedback_repo.get_by_id.return_value = SimpleNamespace(
+        id=3, name='Rejected'
+    )
+
+    with pytest.raises(
+        BusinessRuleViolation, match='Offer final step requires Accepted feedback'
+    ):
+        await uc.execute(id=1, user_id=1, data=_data(step_id=2, feedback_id=3))
+
+
+async def test_finalize_accepted_requires_offer_step():
+    uc = FinalizeApplicationUseCase(
+        AsyncMock(), AsyncMock(), AsyncMock(), AsyncMock()
+    )
+    uc.application_repo.get_by_id_and_user_id.return_value = (
+        make_application()
+    )
+    uc.step_repo.get_by_id_strict_only.return_value = SimpleNamespace(
+        id=2, name='Denied'
+    )
+    uc.feedback_repo.get_by_id.return_value = SimpleNamespace(
+        id=3, name='Accepted'
+    )
+
+    with pytest.raises(
+        BusinessRuleViolation,
+        match='Accepted feedback requires the Offer final step',
+    ):
+        await uc.execute(id=1, user_id=1, data=_data(step_id=2, feedback_id=3))
+
+
+async def test_finalize_salary_offer_requires_offer_and_accepted():
+    uc = FinalizeApplicationUseCase(
+        AsyncMock(), AsyncMock(), AsyncMock(), AsyncMock()
+    )
+    uc.application_repo.get_by_id_and_user_id.return_value = (
+        make_application()
+    )
+    uc.step_repo.get_by_id_strict_only.return_value = SimpleNamespace(
+        id=2, name='Denied'
+    )
+    uc.feedback_repo.get_by_id.return_value = SimpleNamespace(
+        id=3, name='Rejected'
+    )
+
+    with pytest.raises(
+        BusinessRuleViolation,
+        match='salary_offer can only be set for Offer \\+ Accepted',
+    ):
+        await uc.execute(
+            id=1,
+            user_id=1,
+            data=_data(step_id=2, feedback_id=3, salary_offer=90000.0),
+        )

--- a/cli/README.md
+++ b/cli/README.md
@@ -365,7 +365,7 @@ Notes:
 
 ### `applika skill`
 
-Installs the bundled AI skill into your assistant's skills directory. The skill teaches Claude Code, Gemini, or Codex how to use this CLI — what commands exist, how authentication works, required vs optional flags, and common workflows.
+Installs the bundled AI skill into your assistant's skills directory. The skill teaches Claude Code, Gemini, Codex, or OpenCode how to use this CLI — what commands exist, how authentication works, required vs optional flags, and common workflows.
 
 The skill file is shipped inside the installed package (`applika/skills/applika-cli/SKILL.md`) so it stays in sync with the CLI version you have installed. By default the command creates a symlink so updates are reflected automatically; it falls back to a file copy if symlink creation fails (e.g. Windows without Developer Mode enabled).
 
@@ -375,7 +375,8 @@ applika skill
 # →  1. Claude   (~/.claude/skills/applika-cli)
 # →  2. Gemini   (~/.gemini/skills/applika-cli)
 # →  3. Codex    (~/.codex/skills/applika-cli)
-# →  4. All of the above
+# →  4. OpenCode (~/.agents/skills/applika-cli)
+# →  5. All of the above
 
 # Install to the current project's .claude/skills/ (file copy, no prompt)
 # Useful when you want the skill scoped to a single repo

--- a/cli/README.md
+++ b/cli/README.md
@@ -23,12 +23,26 @@ This installs the `applika` binary globally. Verify:
 
 ```bash
 applika --help
+applika --version
+applika version
 ```
 
-To install from a local source checkout (useful during development):
+`applika --version` shows the installed CLI version.
+`applika version` checks PyPI and shows the latest published version alongside
+the installed one.
+
+To run from a local source checkout during development:
 
 ```bash
-uv tool install --force .
+uv sync
+uv run applika --help
+```
+
+If you want the global `applika` command to point at your local checkout while
+you develop, install it in editable mode:
+
+```bash
+uv tool install --force --editable .
 ```
 
 ---
@@ -198,6 +212,154 @@ applika applications list --search "company name" --output-format json
 | `--clear salary` | All salary fields at once (`expected_salary`, `salary_min`, `salary_max`, `currency`, `salary_period`) |
 
 > Finalized applications (those with a recorded outcome) are read-only and cannot be edited. The CLI checks this before sending the request.
+
+---
+
+### `applika applications steps list <application-id>`
+
+Lists the recorded timeline steps for one application.
+
+```bash
+# Human-readable table
+applika applications steps list 42
+
+# JSON output for scripting
+applika applications steps list 42 --output-format json
+```
+
+Each row uses the recorded step entry `id`, which is the identifier needed for
+`steps edit` and `steps delete`.
+
+---
+
+### `applika applications steps add <application-id>`
+
+Adds a non-final step to an active application.
+
+```bash
+applika applications steps add 42 \
+  --step "Initial Screen" \
+  --date 2026-05-11
+
+applika applications steps add 42 \
+  --step "Phase 2" \
+  --date 2026-05-14 \
+  --start-time 14:00 \
+  --end-time 15:00 \
+  --timezone America/Sao_Paulo \
+  --observation "Panel with hiring manager"
+```
+
+Notes:
+- `--step` accepts a predefined non-strict step definition name or ID from `/supports`, such as `Initial Screen`, `Phase 2`, `Phase 3`, or `Phase 4`.
+- Interview labels like `Manager Interview` belong in `--observation`, not `--step`, unless they were explicitly created as step definitions in supports.
+- `--start-time` and `--end-time` must be provided together.
+- Finalized applications reject step mutations.
+
+---
+
+### `applika applications steps edit <application-id> <step-record-id>`
+
+Updates an existing recorded step. Unspecified fields keep their current value.
+
+```bash
+# Change only the step definition
+applika applications steps edit \
+  --application-id 42 \
+  --step-record-id 500 \
+  --step "Phase 2"
+
+# Clear notes and time while keeping the date
+applika applications steps edit \
+  --application-id 42 \
+  --step-record-id 500 \
+  --clear observation \
+  --clear time
+
+# Update the time window
+applika applications steps edit \
+  --application-id 42 \
+  --step-record-id 500 \
+  --start-time 15:00 \
+  --end-time 16:00 \
+  --timezone America/Sao_Paulo
+```
+
+The positional form still works for backward compatibility:
+
+```bash
+applika applications steps edit 42 500 --step "Phase 2"
+```
+
+**Clear flags** — pass `--clear <field>` (repeatable):
+
+| Flag | Clears |
+|---|---|
+| `--clear observation` | Step notes |
+| `--clear time` | Both `start_time` and `end_time` |
+| `--clear timezone` | Step timezone |
+
+---
+
+### `applika applications steps delete <application-id> <step-record-id>`
+
+Deletes a recorded step from an active application.
+
+Preferred explicit form:
+
+```bash
+applika applications steps delete \
+  --application-id 42 \
+  --step-record-id 500
+```
+
+The positional form still works:
+
+```bash
+applika applications steps delete 42 500
+```
+
+```bash
+applika applications steps delete 42 500
+```
+
+---
+
+### `applika applications finalize <application-id>`
+
+Finalizes an application by recording a strict final step plus a feedback
+definition. This is the CLI path for outcomes like rejected, denied, accepted,
+or offer, depending on the backend definitions available in `/supports`.
+
+```bash
+# Finalize as rejected
+applika applications finalize 42 \
+  --step "Denied" \
+  --feedback "Rejected" \
+  --date 2026-05-18 \
+  --observation "Closed after take-home"
+
+# JSON output for scripting
+applika applications finalize 42 \
+  --step "Denied" \
+  --feedback "Rejected" \
+  --date 2026-05-18 \
+  --output-format json
+
+# Finalize with an accepted offer
+applika applications finalize 42 \
+  --step "Offer" \
+  --feedback "Accepted" \
+  --date 2026-05-18 \
+  --salary-offer 180000 \
+  --observation "Signed the offer"
+```
+
+Notes:
+- `--step` accepts only strict final steps.
+- `--feedback` accepts a feedback definition name or ID.
+- Once finalized, the application and its steps become immutable.
+- `--output-format` supports `table` (default summary output) and `json`.
 
 ---
 

--- a/cli/src/applika/app.py
+++ b/cli/src/applika/app.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from importlib.metadata import version
 from typing import Annotated
 
 import typer
@@ -8,6 +7,7 @@ import typer
 from applika.commands.applications import applications_app
 from applika.commands.auth import login, logout, whoami
 from applika.commands.skill import skill
+from applika.commands.version import installed_version, version
 from applika.config import AppConfig, resolve_api_base_url
 from applika.lib.session import SessionStore
 
@@ -22,6 +22,7 @@ app.command('skill')(skill)
 app.command('login')(login)
 app.command('logout')(logout)
 app.command('whoami')(whoami)
+app.command('version')(version)
 
 
 @app.callback()
@@ -47,7 +48,7 @@ def _root(
     ] = False,
 ) -> None:
     if _version:
-        typer.echo(version('applika-cli'))
+        typer.echo(installed_version())
         raise typer.Exit()
     if ctx.invoked_subcommand is None:
         typer.echo(ctx.get_help())

--- a/cli/src/applika/commands/applications/__init__.py
+++ b/cli/src/applika/commands/applications/__init__.py
@@ -1,7 +1,12 @@
 import typer
 
 from applika.commands.applications.commands import (
+    add_application_step,
+    delete_application_step,
     edit_application,
+    edit_application_step,
+    finalize_application,
+    list_application_steps,
     list_applications,
     new_application,
 )
@@ -23,3 +28,17 @@ def _default(ctx: typer.Context) -> None:
 applications_app.command('list')(list_applications)
 applications_app.command('new')(new_application)
 applications_app.command('edit')(edit_application)
+applications_app.command('finalize')(finalize_application)
+
+steps_app = typer.Typer(
+    name='steps',
+    help='Manage recorded application steps.',
+    no_args_is_help=True,
+)
+
+steps_app.command('list')(list_application_steps)
+steps_app.command('add')(add_application_step)
+steps_app.command('edit')(edit_application_step)
+steps_app.command('delete')(delete_application_step)
+
+applications_app.add_typer(steps_app, name='steps')

--- a/cli/src/applika/commands/applications/api_resolve.py
+++ b/cli/src/applika/commands/applications/api_resolve.py
@@ -1,6 +1,13 @@
+from typing import Any
+
 from applika.lib.api import ApiClient
 from applika.schemas.application import ApplicationCompany
-from applika.schemas.supports import Company, SupportSchema
+from applika.schemas.supports import (
+    Company,
+    FeedbackDefinitionSchema,
+    StepDefinitionSchema,
+    SupportSchema,
+)
 
 
 def resolve_platform_id(client: ApiClient, platform_name: str) -> str:
@@ -26,6 +33,33 @@ def resolve_platform_id(client: ApiClient, platform_name: str) -> str:
         raise ValueError(f'Unknown platform. Valid options: {valid}')
 
     return str(match['id'])
+
+
+def resolve_step_id(
+    supports: SupportSchema,
+    step_name_or_id: str,
+    *,
+    strict: bool,
+) -> str:
+    steps = [
+        step for step in supports['steps'] if bool(step['strict']) is strict
+    ]
+    return _resolve_named_support_item(
+        steps,
+        step_name_or_id,
+        label='step',
+    )
+
+
+def resolve_feedback_id(
+    supports: SupportSchema,
+    feedback_name_or_id: str,
+) -> str:
+    return _resolve_named_support_item(
+        supports['feedbacks'],
+        feedback_name_or_id,
+        label='feedback',
+    )
 
 
 def resolve_company_input(
@@ -54,3 +88,38 @@ def resolve_company_input(
         return str(exact_match['id'])
 
     return {'name': company_name.strip(), 'url': company_url or None}
+
+
+def _resolve_named_support_item(
+    items: list[StepDefinitionSchema] | list[FeedbackDefinitionSchema],
+    name_or_id: str,
+    *,
+    label: str,
+) -> str:
+    query = name_or_id.strip()
+    normalized_query = query.lower()
+
+    exact_id_match = next(
+        (item for item in items if str(item['id']) == query),
+        None,
+    )
+    if exact_id_match is not None:
+        return str(exact_id_match['id'])
+
+    exact_name_match = next(
+        (
+            item
+            for item in items
+            if item['name'].strip().lower() == normalized_query
+        ),
+        None,
+    )
+    if exact_name_match is not None:
+        return str(exact_name_match['id'])
+
+    valid = ', '.join(sorted(_support_item_name(item) for item in items))
+    raise ValueError(f'Unknown {label}. Valid options: {valid}')
+
+
+def _support_item_name(item: dict[str, Any]) -> str:
+    return str(item['name'])

--- a/cli/src/applika/commands/applications/commands.py
+++ b/cli/src/applika/commands/applications/commands.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
 import json
-from typing import Annotated, Any
+from typing import Annotated
 
 import typer
 from pydantic import ValidationError
 
 from applika.commands.applications.api_resolve import (
     resolve_company_input,
+    resolve_feedback_id,
     resolve_platform_id,
+    resolve_step_id,
 )
 from applika.commands.applications.filter import filter_applications
 from applika.config import AppConfig
@@ -17,6 +19,12 @@ from applika.schemas.application import (
     ApplicationCreate,
     ApplicationEntry,
     ApplicationUpdate,
+)
+from applika.schemas.application_step import (
+    ApplicationStepCreate,
+    ApplicationStepEntry,
+    ApplicationStepUpdate,
+    FinalizeApplication,
 )
 from applika.schemas.enums import (
     ApplicationMode,
@@ -27,11 +35,15 @@ from applika.schemas.enums import (
     OutputFormat,
     SalaryPeriod,
     StatusFilter,
+    StepClearField,
     WorkMode,
 )
 from applika.schemas.supports import SupportSchema
 from applika.utils.output import (
+    print_application_step_summary,
     print_application_summary,
+    print_finalize_summary,
+    render_application_step_table,
     render_application_table,
 )
 
@@ -111,6 +123,8 @@ def list_applications(
             print(json.dumps(filtered, indent=2, sort_keys=True))
         else:
             render_application_table(filtered, supports)
+    except ValueError as exc:
+        _echo_value_error(exc)
     finally:
         client.close()
 
@@ -221,10 +235,9 @@ def new_application(
         )
         print_application_summary(created, 'Created application')
     except ValidationError as exc:
-        for err in exc.errors():
-            field = '.'.join(str(loc) for loc in err['loc'])
-            typer.echo(f'Error [{field}]: {err["msg"]}', err=True)
-        raise typer.Exit(1)
+        _echo_validation_error(exc)
+    except ValueError as exc:
+        _echo_value_error(exc)
     finally:
         client.close()
 
@@ -320,7 +333,7 @@ def edit_application(
     client = ApiClient(session, config.store)
 
     try:
-        applications: list[dict[str, Any]] = client.get_json('/applications')
+        applications: list[ApplicationEntry] = client.get_json('/applications')
         existing = next(
             (app for app in applications if str(app['id']) == application_id),
             None,
@@ -357,7 +370,7 @@ def edit_application(
             role=role or existing['role'],
             mode=mode or existing['mode'],
             platform_id=resolved_platform_id,
-            application_date=(application_date or existing['application_date']),
+            application_date=application_date or existing['application_date'],
             link_to_job=(
                 None
                 if _clears(ClearField.JOB_URL)
@@ -427,9 +440,479 @@ def edit_application(
         )
         print_application_summary(updated, 'Updated application')
     except ValidationError as exc:
-        for err in exc.errors():
-            field = '.'.join(str(loc) for loc in err['loc'])
-            typer.echo(f'Error [{field}]: {err["msg"]}', err=True)
-        raise typer.Exit(1)
+        _echo_validation_error(exc)
+    except ValueError as exc:
+        _echo_value_error(exc)
     finally:
         client.close()
+
+
+def list_application_steps(
+    ctx: typer.Context,
+    application_id_arg: Annotated[
+        str | None,
+        typer.Argument(help='ID of the application to inspect.'),
+    ] = None,
+    application_id: Annotated[
+        str | None,
+        typer.Option(
+            '--application-id', help='ID of the application to inspect.'
+        ),
+    ] = None,
+    output_format: Annotated[
+        OutputFormat,
+        typer.Option(
+            '--output-format', help='Output format: table (default) or json.'
+        ),
+    ] = OutputFormat.TABLE,
+) -> None:
+    """List the recorded steps for an application."""
+    config: AppConfig = ctx.obj
+    session = require_session(config.store)
+    client = ApiClient(session, config.store)
+
+    try:
+        resolved_application_id = _resolve_identifier(
+            label='application id',
+            positional=application_id_arg,
+            option=application_id,
+            option_name='--application-id',
+        )
+        steps = _sorted_steps(
+            client.get_json(f'/applications/{resolved_application_id}/steps')
+        )
+        if output_format == OutputFormat.JSON:
+            print(json.dumps(steps, indent=2, sort_keys=True))
+        else:
+            render_application_step_table(steps)
+    finally:
+        client.close()
+
+
+def add_application_step(
+    ctx: typer.Context,
+    application_id_arg: Annotated[
+        str | None,
+        typer.Argument(help='ID of the application to update.'),
+    ] = None,
+    application_id: Annotated[
+        str | None,
+        typer.Option(
+            '--application-id', help='ID of the application to update.'
+        ),
+    ] = None,
+    step: Annotated[
+        str,
+        typer.Option(
+            '--step',
+            help='Predefined non-final step definition name or ID (e.g. Phase 2).',
+        ),
+    ] = ...,
+    step_date: Annotated[
+        str,
+        typer.Option('--date', help='Step date (YYYY-MM-DD).'),
+    ] = ...,
+    start_time: Annotated[
+        str | None,
+        typer.Option(
+            '--start-time', help='Step start time (HH:MM or HH:MM:SS).'
+        ),
+    ] = None,
+    end_time: Annotated[
+        str | None,
+        typer.Option('--end-time', help='Step end time (HH:MM or HH:MM:SS).'),
+    ] = None,
+    timezone: Annotated[
+        str | None,
+        typer.Option(
+            '--timezone', help='IANA timezone (e.g. America/Sao_Paulo).'
+        ),
+    ] = None,
+    observation: Annotated[
+        str | None,
+        typer.Option('--observation', help='Notes for this step.'),
+    ] = None,
+) -> None:
+    """Add a recorded step to an active application."""
+    config: AppConfig = ctx.obj
+    session = require_session(config.store)
+    client = ApiClient(session, config.store)
+
+    try:
+        resolved_application_id = _resolve_identifier(
+            label='application id',
+            positional=application_id_arg,
+            option=application_id,
+            option_name='--application-id',
+        )
+        _reject_if_application_finalized(client, resolved_application_id)
+        supports: SupportSchema = client.get_json('/supports')
+        payload = ApplicationStepCreate(
+            step_id=resolve_step_id(supports, step, strict=False),
+            step_date=step_date,
+            start_time=start_time,
+            end_time=end_time,
+            timezone=timezone,
+            observation=observation,
+        )
+        created = client.post_json(
+            f'/applications/{resolved_application_id}/steps',
+            payload.model_dump(mode='json'),
+        )
+        print_application_step_summary(created, 'Added step')
+    except ValidationError as exc:
+        _echo_validation_error(exc)
+    except ValueError as exc:
+        _echo_value_error(exc)
+    finally:
+        client.close()
+
+
+def edit_application_step(
+    ctx: typer.Context,
+    application_id_arg: Annotated[
+        str | None,
+        typer.Argument(help='ID of the application to update.'),
+    ] = None,
+    step_record_id_arg: Annotated[
+        str | None,
+        typer.Argument(help='Recorded step ID to edit.'),
+    ] = None,
+    application_id: Annotated[
+        str | None,
+        typer.Option(
+            '--application-id', help='ID of the application to update.'
+        ),
+    ] = None,
+    step_record_id: Annotated[
+        str | None,
+        typer.Option('--step-record-id', help='Recorded step ID to edit.'),
+    ] = None,
+    step: Annotated[
+        str | None,
+        typer.Option(
+            '--step',
+            help='New predefined non-final step definition name or ID.',
+        ),
+    ] = None,
+    step_date: Annotated[
+        str | None,
+        typer.Option('--date', help='New step date (YYYY-MM-DD).'),
+    ] = None,
+    start_time: Annotated[
+        str | None,
+        typer.Option(
+            '--start-time', help='New start time (HH:MM or HH:MM:SS).'
+        ),
+    ] = None,
+    end_time: Annotated[
+        str | None,
+        typer.Option('--end-time', help='New end time (HH:MM or HH:MM:SS).'),
+    ] = None,
+    timezone: Annotated[
+        str | None,
+        typer.Option('--timezone', help='New IANA timezone.'),
+    ] = None,
+    observation: Annotated[
+        str | None,
+        typer.Option('--observation', help='New notes for this step.'),
+    ] = None,
+    clear: Annotated[
+        list[StepClearField] | None,
+        typer.Option(
+            '--clear',
+            help=(
+                'Field to set to null. Repeatable. '
+                'Valid: observation, time, timezone.'
+            ),
+        ),
+    ] = None,
+) -> None:
+    """Edit a recorded application step. Unspecified fields keep their current values."""
+    config: AppConfig = ctx.obj
+    session = require_session(config.store)
+    client = ApiClient(session, config.store)
+
+    try:
+        resolved_application_id = _resolve_identifier(
+            label='application id',
+            positional=application_id_arg,
+            option=application_id,
+            option_name='--application-id',
+        )
+        resolved_step_record_id = _resolve_identifier(
+            label='step record id',
+            positional=step_record_id_arg,
+            option=step_record_id,
+            option_name='--step-record-id',
+        )
+        _reject_if_application_finalized(client, resolved_application_id)
+        existing = _get_application_step_or_exit(
+            client, resolved_application_id, resolved_step_record_id
+        )
+        supports: SupportSchema = client.get_json('/supports')
+        clear_set = set(clear or [])
+        clear_time = StepClearField.TIME in clear_set
+        clear_timezone = StepClearField.TIMEZONE in clear_set
+        clear_observation = StepClearField.OBSERVATION in clear_set
+
+        payload = ApplicationStepUpdate(
+            step_id=(
+                resolve_step_id(supports, step, strict=False)
+                if step is not None
+                else str(existing['step_id'])
+            ),
+            step_date=step_date or existing['step_date'],
+            start_time=(
+                None
+                if clear_time
+                else start_time
+                if start_time is not None
+                else existing.get('start_time')
+            ),
+            end_time=(
+                None
+                if clear_time
+                else end_time
+                if end_time is not None
+                else existing.get('end_time')
+            ),
+            timezone=(
+                None
+                if clear_timezone
+                else timezone
+                if timezone is not None
+                else existing.get('timezone')
+            ),
+            observation=(
+                None
+                if clear_observation
+                else observation
+                if observation is not None
+                else existing.get('observation')
+            ),
+        )
+        updated = client.put_json(
+            f'/applications/{resolved_application_id}/steps/{resolved_step_record_id}',
+            payload.model_dump(mode='json'),
+        )
+        print_application_step_summary(updated, 'Updated step')
+    except ValidationError as exc:
+        _echo_validation_error(exc)
+    except ValueError as exc:
+        _echo_value_error(exc)
+    finally:
+        client.close()
+
+
+def delete_application_step(
+    ctx: typer.Context,
+    application_id_arg: Annotated[
+        str | None,
+        typer.Argument(help='ID of the application to update.'),
+    ] = None,
+    step_record_id_arg: Annotated[
+        str | None,
+        typer.Argument(help='Recorded step ID to delete.'),
+    ] = None,
+    application_id: Annotated[
+        str | None,
+        typer.Option(
+            '--application-id', help='ID of the application to update.'
+        ),
+    ] = None,
+    step_record_id: Annotated[
+        str | None,
+        typer.Option('--step-record-id', help='Recorded step ID to delete.'),
+    ] = None,
+) -> None:
+    """Delete a recorded application step."""
+    config: AppConfig = ctx.obj
+    session = require_session(config.store)
+    client = ApiClient(session, config.store)
+
+    try:
+        resolved_application_id = _resolve_identifier(
+            label='application id',
+            positional=application_id_arg,
+            option=application_id,
+            option_name='--application-id',
+        )
+        resolved_step_record_id = _resolve_identifier(
+            label='step record id',
+            positional=step_record_id_arg,
+            option=step_record_id,
+            option_name='--step-record-id',
+        )
+        _reject_if_application_finalized(client, resolved_application_id)
+        _get_application_step_or_exit(
+            client, resolved_application_id, resolved_step_record_id
+        )
+        client.delete(
+            f'/applications/{resolved_application_id}/steps/{resolved_step_record_id}'
+        )
+        typer.echo(f'Deleted step: id={resolved_step_record_id}')
+    finally:
+        client.close()
+
+
+def finalize_application(
+    ctx: typer.Context,
+    application_id_arg: Annotated[
+        str | None,
+        typer.Argument(help='ID of the application to finalize.'),
+    ] = None,
+    application_id: Annotated[
+        str | None,
+        typer.Option(
+            '--application-id', help='ID of the application to finalize.'
+        ),
+    ] = None,
+    step: Annotated[
+        str,
+        typer.Option(
+            '--step',
+            help='Final strict step definition name or ID (e.g. Offer, Denied).',
+        ),
+    ] = ...,
+    feedback: Annotated[
+        str,
+        typer.Option(
+            '--feedback',
+            help='Feedback definition name or ID (e.g. Accepted, Rejected).',
+        ),
+    ] = ...,
+    finalize_date: Annotated[
+        str,
+        typer.Option('--date', help='Finalization date (YYYY-MM-DD).'),
+    ] = ...,
+    salary_offer: Annotated[
+        float | None,
+        typer.Option('--salary-offer', help='Final salary offer amount.'),
+    ] = None,
+    observation: Annotated[
+        str | None,
+        typer.Option('--observation', help='Final notes or observations.'),
+    ] = None,
+    output_format: Annotated[
+        OutputFormat,
+        typer.Option(
+            '--output-format', help='Output format: table (default) or json.'
+        ),
+    ] = OutputFormat.TABLE,
+) -> None:
+    """Finalize an application with a strict final step and feedback."""
+    config: AppConfig = ctx.obj
+    session = require_session(config.store)
+    client = ApiClient(session, config.store)
+
+    try:
+        resolved_application_id = _resolve_identifier(
+            label='application id',
+            positional=application_id_arg,
+            option=application_id,
+            option_name='--application-id',
+        )
+        supports: SupportSchema = client.get_json('/supports')
+        payload = FinalizeApplication(
+            step_id=resolve_step_id(supports, step, strict=True),
+            feedback_id=resolve_feedback_id(supports, feedback),
+            finalize_date=finalize_date,
+            salary_offer=salary_offer,
+            observation=observation,
+        )
+        finalized = client.post_json(
+            f'/applications/{resolved_application_id}/finalize',
+            payload.model_dump(mode='json'),
+        )
+        if output_format == OutputFormat.JSON:
+            print(json.dumps(finalized, indent=2, sort_keys=True))
+        else:
+            print_finalize_summary(finalized, 'Finalized application')
+    except ValidationError as exc:
+        _echo_validation_error(exc)
+    except ValueError as exc:
+        _echo_value_error(exc)
+    finally:
+        client.close()
+
+
+def _echo_validation_error(exc: ValidationError) -> None:
+    for err in exc.errors():
+        field = '.'.join(str(loc) for loc in err['loc'])
+        typer.echo(f'Error [{field}]: {err["msg"]}', err=True)
+    raise typer.Exit(1)
+
+
+def _resolve_identifier(
+    *,
+    label: str,
+    positional: str | None,
+    option: str | None,
+    option_name: str,
+) -> str:
+    if positional and option and positional != option:
+        typer.echo(
+            f'Conflicting {label}: positional value "{positional}" does not match {option_name} "{option}"',
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    value = option or positional
+    if value is None:
+        typer.echo(
+            f'Missing {label}. Provide it positionally or with {option_name}.',
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    return value
+
+
+def _echo_value_error(exc: ValueError) -> None:
+    typer.echo(str(exc), err=True)
+    raise typer.Exit(1)
+
+
+def _get_application_step_or_exit(
+    client: ApiClient,
+    application_id: str,
+    step_record_id: str,
+) -> ApplicationStepEntry:
+    steps: list[ApplicationStepEntry] = client.get_json(
+        f'/applications/{application_id}/steps'
+    )
+    existing = next(
+        (step for step in steps if str(step['id']) == step_record_id), None
+    )
+    if existing is None:
+        typer.echo('Application step not found', err=True)
+        raise typer.Exit(1)
+    return existing
+
+
+def _reject_if_application_finalized(
+    client: ApiClient,
+    application_id: str,
+) -> None:
+    applications: list[ApplicationEntry] = client.get_json('/applications')
+    existing = next(
+        (app for app in applications if str(app['id']) == application_id),
+        None,
+    )
+    if existing is not None and existing.get('finalized'):
+        typer.echo('This application has already been finalized', err=True)
+        raise typer.Exit(1)
+
+
+def _sorted_steps(
+    steps: list[ApplicationStepEntry],
+) -> list[ApplicationStepEntry]:
+    return sorted(
+        steps,
+        key=lambda step: (
+            step['step_date'],
+            step.get('start_time') or '',
+            str(step['id']),
+        ),
+    )

--- a/cli/src/applika/commands/skill.py
+++ b/cli/src/applika/commands/skill.py
@@ -13,6 +13,7 @@ _TOOLS: list[tuple[str, Path]] = [
     ('Claude', Path.home() / '.claude' / 'skills'),
     ('Gemini', Path.home() / '.gemini' / 'skills'),
     ('Codex', Path.home() / '.codex' / 'skills'),
+    ('OpenCode', Path.home() / '.agents' / 'skills'),
 ]
 
 
@@ -95,9 +96,9 @@ def skill(
     """Install the applika-cli AI skill into your assistant's skills directory.
 
     By default, opens an interactive picker to choose Claude, Gemini, Codex,
-    or all of them. Symlinks the bundled skill directory; falls back to a file
-    copy automatically if symlink creation fails (e.g. Windows without
-    Developer Mode).
+    OpenCode, or all of them. Symlinks the bundled skill directory; falls
+    back to a file copy automatically if symlink creation fails (e.g.
+    Windows without Developer Mode).
 
     Use --local or --dir to skip the picker and install as a file copy.
     """

--- a/cli/src/applika/commands/version.py
+++ b/cli/src/applika/commands/version.py
@@ -1,0 +1,32 @@
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as package_version
+
+import httpx
+import typer
+
+_PACKAGE_NAME = 'applika-cli'
+_PYPI_JSON_URL = f'https://pypi.org/pypi/{_PACKAGE_NAME}/json'
+
+
+def installed_version() -> str:
+    try:
+        return package_version(_PACKAGE_NAME)
+    except PackageNotFoundError:
+        return 'unknown'
+
+
+def version() -> None:
+    """Show the installed CLI version and the latest published PyPI version."""
+    installed = installed_version()
+
+    try:
+        response = httpx.get(_PYPI_JSON_URL, timeout=10)
+        response.raise_for_status()
+        published = response.json()['info']['version']
+    except (httpx.HTTPError, KeyError, ValueError) as exc:
+        typer.echo(f'installed: {installed}')
+        typer.echo(f'published: unavailable ({exc})')
+        return
+
+    typer.echo(f'installed: {installed}')
+    typer.echo(f'published: {published}')

--- a/cli/src/applika/lib/api.py
+++ b/cli/src/applika/lib/api.py
@@ -137,6 +137,9 @@ class ApiClient:
     def put_json(self, path: str, payload: dict[str, Any]) -> Any:
         return self.request('PUT', path, json=payload).json()
 
+    def delete(self, path: str) -> None:
+        self.request('DELETE', path)
+
     def logout(self) -> None:
         try:
             self.client.get('/auth/logout')

--- a/cli/src/applika/schemas/application.py
+++ b/cli/src/applika/schemas/application.py
@@ -52,9 +52,24 @@ class ApplicationCreate(BaseModel):
 class ApplicationUpdate(ApplicationCreate): ...
 
 
+class ApplicationLastStep(TypedDict):
+    id: str
+    name: str
+    color: str
+    date: str
+
+
+class ApplicationFeedback(TypedDict):
+    id: str
+    name: str
+    color: str
+    date: str
+
+
 class ApplicationEntry(TypedDict):
     id: str
-    company: ApplicationCompany
+    company_id: str | None
+    company_name: str
     role: str
     mode: str
     platform_id: str
@@ -69,3 +84,7 @@ class ApplicationEntry(TypedDict):
     experience_level: str | None
     work_mode: str | None
     country: str | None
+    salary_offer: float | None
+    finalized: bool
+    last_step: ApplicationLastStep | None
+    feedback: ApplicationFeedback | None

--- a/cli/src/applika/schemas/application_step.py
+++ b/cli/src/applika/schemas/application_step.py
@@ -1,0 +1,56 @@
+import datetime
+
+from pydantic import BaseModel, model_validator
+from typing_extensions import TypedDict
+
+
+def _parse_time(value: str) -> datetime.time:
+    return datetime.time.fromisoformat(value)
+
+
+class _ApplicationStepBase(BaseModel):
+    step_id: str
+    step_date: datetime.date
+    start_time: str | None = None
+    end_time: str | None = None
+    timezone: str | None = None
+    observation: str | None = None
+
+    @model_validator(mode='after')
+    def validate_time_range(self) -> '_ApplicationStepBase':
+        if bool(self.start_time) != bool(self.end_time):
+            raise ValueError(
+                'start-time and end-time must be provided together'
+            )
+        if (
+            self.start_time is not None
+            and self.end_time is not None
+            and _parse_time(self.end_time) <= _parse_time(self.start_time)
+        ):
+            raise ValueError('end-time must be after start-time')
+        return self
+
+
+class ApplicationStepCreate(_ApplicationStepBase): ...
+
+
+class ApplicationStepUpdate(_ApplicationStepBase): ...
+
+
+class ApplicationStepEntry(TypedDict):
+    id: str
+    step_id: str
+    step_name: str | None
+    step_date: str
+    start_time: str | None
+    end_time: str | None
+    timezone: str | None
+    observation: str | None
+
+
+class FinalizeApplication(BaseModel):
+    step_id: str
+    feedback_id: str
+    finalize_date: datetime.date
+    salary_offer: float | None = None
+    observation: str | None = None

--- a/cli/src/applika/schemas/enums.py
+++ b/cli/src/applika/schemas/enums.py
@@ -70,3 +70,9 @@ class ClearField(str, Enum):
     CURRENCY = 'currency'
     SALARY_PERIOD = 'salary_period'
     SALARY = 'salary'
+
+
+class StepClearField(str, Enum):
+    OBSERVATION = 'observation'
+    TIME = 'time'
+    TIMEZONE = 'timezone'

--- a/cli/src/applika/skills/applika-cli/SKILL.md
+++ b/cli/src/applika/skills/applika-cli/SKILL.md
@@ -252,3 +252,163 @@ Verify:
 applika --help
 applika whoami
 ```
+
+---
+
+## 8. Application Steps and Finalization
+
+Application steps are timeline entries inside one application. Finalization is
+separate and irreversible.
+
+Important distinction:
+- Normal steps are used while the application is active.
+- Strict steps are final-only and can only be used during finalization.
+
+### List recorded steps for an application
+
+```bash
+applika applications steps list <application-id>
+applika applications steps list <application-id> --output-format json
+```
+
+Use this to find the recorded step entry `id` needed by `steps edit` and
+`steps delete`.
+
+### Add a step
+
+```bash
+applika applications steps add <application-id> \
+  --step "Initial Screen" \
+  --date 2026-05-11
+
+applika applications steps add <application-id> \
+  --step "Phase 2" \
+  --date 2026-05-14 \
+  --start-time 14:00 \
+  --end-time 15:00 \
+  --timezone America/Sao_Paulo \
+  --observation "Panel interview"
+```
+
+Rules:
+- `--step` must be a predefined non-strict step definition from supports, such as `Initial Screen`, `Phase 2`, `Phase 3`, or `Phase 4`.
+- Interview labels like `Manager Interview` belong in `--observation`, not `--step`, unless they were explicitly created as step definitions in supports.
+- `--start-time` and `--end-time` must be provided together.
+- `--end-time` must be after `--start-time`.
+- Finalized applications reject step mutations.
+
+### Edit a recorded step
+
+```bash
+applika applications steps edit \
+  --application-id <application-id> \
+  --step-record-id <step-record-id> \
+  --step "Phase 2"
+
+applika applications steps edit \
+  --application-id <application-id> \
+  --step-record-id <step-record-id> \
+  --clear observation \
+  --clear time
+
+applika applications steps edit \
+  --application-id <application-id> \
+  --step-record-id <step-record-id> \
+  --start-time 15:00 \
+  --end-time 16:00 \
+  --timezone America/Sao_Paulo
+```
+
+`steps edit` keeps unspecified fields unchanged.
+The positional form still works: `applika applications steps edit <application-id> <step-record-id> ...`
+
+Supported clear flags:
+- `--clear observation`
+- `--clear time`
+- `--clear timezone`
+
+### Delete a recorded step
+
+```bash
+applika applications steps delete \
+  --application-id <application-id> \
+  --step-record-id <step-record-id>
+```
+
+The positional form still works: `applika applications steps delete <application-id> <step-record-id>`
+
+### Finalize an application
+
+```bash
+applika applications finalize <application-id> \
+  --step "Denied" \
+  --feedback "Rejected" \
+  --date 2026-05-18 \
+  --observation "Closed after take-home"
+
+applika applications finalize <application-id> \
+  --step "Denied" \
+  --feedback "Rejected" \
+  --date 2026-05-18 \
+  --output-format json
+
+applika applications finalize <application-id> \
+  --step "Offer" \
+  --feedback "Accepted" \
+  --date 2026-05-18 \
+  --salary-offer 180000 \
+  --observation "Signed the offer"
+```
+
+Rules:
+- `--step` must be a strict final step definition.
+- `--feedback` must be a feedback definition.
+- `--salary-offer` is optional and useful for accepted/offer outcomes.
+- Once finalized, the application and its steps are no longer editable.
+- `--output-format` supports `table` (default summary output) and `json`.
+
+### Common step/finalize workflows
+
+Find an application ID:
+
+```bash
+applika applications list --search "stripe" --output-format json
+```
+
+Inspect steps to find a step-record ID:
+
+```bash
+applika applications steps list 1234567890123456789 --output-format json
+```
+
+Add interview progression steps:
+
+```bash
+applika applications steps add 1234567890123456789 \
+  --step "Initial Screen" \
+  --date 2026-05-11
+
+applika applications steps add 1234567890123456789 \
+  --step "Phase 2" \
+  --date 2026-05-14 \
+  --observation "Strong technical round"
+```
+
+Finalize as rejected:
+
+```bash
+applika applications finalize 1234567890123456789 \
+  --step "Denied" \
+  --feedback "Rejected" \
+  --date 2026-05-18
+```
+
+Finalize with accepted offer plus salary:
+
+```bash
+applika applications finalize 1234567890123456789 \
+  --step "Offer" \
+  --feedback "Accepted" \
+  --date 2026-05-18 \
+  --salary-offer 180000
+```

--- a/cli/src/applika/utils/output.py
+++ b/cli/src/applika/utils/output.py
@@ -52,3 +52,73 @@ def print_application_summary(application: dict[str, Any], prefix: str) -> None:
         f'role={application["role"]} '
         f'date={application["application_date"]}'
     )
+
+
+def render_application_step_table(steps: list[dict[str, Any]]) -> None:
+    rows = [
+        [
+            str(step['id']),
+            step['step_date'],
+            step.get('step_name') or str(step['step_id']),
+            _format_time_range(step),
+            step.get('timezone') or '-',
+            step.get('observation') or '-',
+        ]
+        for step in steps
+    ]
+    headers = ['id', 'date', 'step', 'time', 'timezone', 'observation']
+    widths = [
+        max(len(header), *(len(row[index]) for row in rows))
+        if rows
+        else len(header)
+        for index, header in enumerate(headers)
+    ]
+
+    print(
+        '  '.join(
+            header.ljust(widths[index]) for index, header in enumerate(headers)
+        )
+    )
+    for row in rows:
+        print(
+            '  '.join(
+                value.ljust(widths[index]) for index, value in enumerate(row)
+            )
+        )
+
+
+def print_application_step_summary(step: dict[str, Any], prefix: str) -> None:
+    print(
+        f'{prefix}: '
+        f'id={step["id"]} '
+        f'step={step.get("step_name") or step["step_id"]} '
+        f'date={step["step_date"]}'
+    )
+
+
+def print_finalize_summary(application: dict[str, Any], prefix: str) -> None:
+    last_step = application.get('last_step') or {}
+    feedback = application.get('feedback') or {}
+    salary_offer = application.get('salary_offer')
+
+    parts = [
+        f'{prefix}:',
+        f'id={application["id"]}',
+        f'company={application["company_name"]}',
+        f'role={application["role"]}',
+        f'final_step={last_step.get("name", "-")}',
+        f'feedback={feedback.get("name", "-")}',
+        f'date={last_step.get("date") or feedback.get("date") or "-"}',
+    ]
+    if salary_offer is not None:
+        parts.append(f'salary_offer={salary_offer}')
+
+    print(' '.join(parts))
+
+
+def _format_time_range(step: dict[str, Any]) -> str:
+    start_time = step.get('start_time')
+    end_time = step.get('end_time')
+    if not start_time or not end_time:
+        return '-'
+    return f'{start_time}-{end_time}'

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 from typer.testing import CliRunner
 
@@ -42,9 +44,16 @@ class FakeApiClient:
     company_matches = []
     created_response = {}
     updated_response = {}
+    step_created_response = {}
+    step_updated_response = {}
+    finalized_response = {}
+    application_steps = {}
     whoami_response = {}
+    captured_post_path = None
     captured_post_payload = None
+    captured_put_path = None
     captured_put_payload = None
+    captured_delete_path = None
     captured_application_params = None
 
     def __init__(self, session, store):
@@ -58,6 +67,9 @@ class FakeApiClient:
         if path == '/applications':
             FakeApiClient.captured_application_params = params
             return FakeApiClient.applications
+        match = re.fullmatch(r'/applications/([^/]+)/steps', path)
+        if match:
+            return FakeApiClient.application_steps.get(match.group(1), [])
         if path == '/supports':
             return FakeApiClient.supports
         if path == '/companies':
@@ -67,14 +79,27 @@ class FakeApiClient:
         raise AssertionError(f'Unexpected GET path: {path}')
 
     def post_json(self, path, payload):
-        assert path == '/applications'
+        FakeApiClient.captured_post_path = path
         FakeApiClient.captured_post_payload = payload
-        return FakeApiClient.created_response
+        if path == '/applications':
+            return FakeApiClient.created_response
+        if re.fullmatch(r'/applications/[^/]+/steps', path):
+            return FakeApiClient.step_created_response
+        if re.fullmatch(r'/applications/[^/]+/finalize', path):
+            return FakeApiClient.finalized_response
+        raise AssertionError(f'Unexpected POST path: {path}')
 
     def put_json(self, path, payload):
-        assert path.startswith('/applications/')
+        FakeApiClient.captured_put_path = path
         FakeApiClient.captured_put_payload = payload
-        return FakeApiClient.updated_response
+        if re.fullmatch(r'/applications/[^/]+/steps/[^/]+', path):
+            return FakeApiClient.step_updated_response
+        if path.startswith('/applications/'):
+            return FakeApiClient.updated_response
+        raise AssertionError(f'Unexpected PUT path: {path}')
+
+    def delete(self, path):
+        FakeApiClient.captured_delete_path = path
 
 
 def reset_fake_client():
@@ -83,7 +108,14 @@ def reset_fake_client():
     FakeApiClient.company_matches = []
     FakeApiClient.created_response = {}
     FakeApiClient.updated_response = {}
+    FakeApiClient.step_created_response = {}
+    FakeApiClient.step_updated_response = {}
+    FakeApiClient.finalized_response = {}
+    FakeApiClient.application_steps = {}
     FakeApiClient.whoami_response = {}
+    FakeApiClient.captured_post_path = None
     FakeApiClient.captured_post_payload = None
+    FakeApiClient.captured_put_path = None
     FakeApiClient.captured_put_payload = None
+    FakeApiClient.captured_delete_path = None
     FakeApiClient.captured_application_params = None

--- a/cli/tests/test_commands.py
+++ b/cli/tests/test_commands.py
@@ -1,12 +1,14 @@
 import json
 
 import httpx
+import pytest
 from conftest import FakeApiClient, FakeStore, make_session, reset_fake_client
 
 import applika.app as cli_app
 import applika.commands.applications.commands as applications_commands
 import applika.commands.auth as auth_commands
 import applika.commands.skill as skill_module
+import applika.commands.version as version_module
 from applika.app import app
 
 
@@ -29,6 +31,31 @@ def _setup(monkeypatch, session=None):
     reset_fake_client()
     monkeypatch.setattr(applications_commands, 'ApiClient', FakeApiClient)
     return store
+
+
+def _supports():
+    return {
+        'platforms': [{'id': '10', 'name': 'LinkedIn'}],
+        'steps': [
+            {
+                'id': '1',
+                'name': 'Initial Screen',
+                'color': '#aaa',
+                'strict': False,
+            },
+            {
+                'id': '2',
+                'name': 'Manager Interview',
+                'color': '#bbb',
+                'strict': False,
+            },
+            {'id': '9', 'name': 'Offer', 'color': '#0f0', 'strict': True},
+        ],
+        'feedbacks': [
+            {'id': '7', 'name': 'Rejected', 'color': '#f00'},
+            {'id': '8', 'name': 'Accepted', 'color': '#0f0'},
+        ],
+    }
 
 
 def test_applications_list_filters_and_outputs_json(monkeypatch, runner):
@@ -269,6 +296,526 @@ def test_applications_edit_rejects_finalized(monkeypatch, runner):
     assert 'Finalized applications cannot be edited' in result.output
 
 
+def test_applications_commands_include_steps_and_finalize(runner):
+    result = runner.invoke(app, ['applications', '--help'])
+
+    assert result.exit_code == 0
+    assert 'steps' in result.output
+    assert 'finalize' in result.output
+
+
+def test_application_steps_help_lists_subcommands(runner):
+    result = runner.invoke(app, ['applications', 'steps', '--help'])
+
+    assert result.exit_code == 0
+    assert 'list' in result.output
+    assert 'add' in result.output
+    assert 'edit' in result.output
+    assert 'delete' in result.output
+
+
+def test_application_steps_list_outputs_table(monkeypatch, runner):
+    _setup(monkeypatch)
+    FakeApiClient.application_steps = {
+        '99': [
+            {
+                'id': '500',
+                'step_id': '1',
+                'step_name': 'Initial Screen',
+                'step_date': '2026-05-11',
+                'start_time': None,
+                'end_time': None,
+                'timezone': None,
+                'observation': None,
+            }
+        ]
+    }
+
+    result = runner.invoke(app, ['applications', 'steps', 'list', '99'])
+
+    assert result.exit_code == 0
+    assert 'Initial Screen' in result.output
+    assert '2026-05-11' in result.output
+
+
+def test_application_steps_list_outputs_json(monkeypatch, runner):
+    _setup(monkeypatch)
+    FakeApiClient.application_steps = {
+        '99': [
+            {
+                'id': '500',
+                'step_id': '1',
+                'step_name': 'Initial Screen',
+                'step_date': '2026-05-11',
+                'start_time': None,
+                'end_time': None,
+                'timezone': None,
+                'observation': None,
+            }
+        ]
+    }
+
+    result = runner.invoke(
+        app,
+        ['applications', 'steps', 'list', '99', '--output-format', 'json'],
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output)[0]['id'] == '500'
+
+
+def test_application_steps_add_builds_matching_payload(monkeypatch, runner):
+    _setup(monkeypatch)
+    FakeApiClient.supports = _supports()
+    FakeApiClient.applications = [{'id': '99', 'finalized': False}]
+    FakeApiClient.step_created_response = {
+        'id': '500',
+        'step_id': '1',
+        'step_name': 'Initial Screen',
+        'step_date': '2026-05-11',
+        'start_time': '09:00',
+        'end_time': '10:00',
+        'timezone': 'America/Sao_Paulo',
+        'observation': 'Met recruiter',
+    }
+
+    result = runner.invoke(
+        app,
+        [
+            'applications',
+            'steps',
+            'add',
+            '99',
+            '--step',
+            'Initial Screen',
+            '--date',
+            '2026-05-11',
+            '--start-time',
+            '09:00',
+            '--end-time',
+            '10:00',
+            '--timezone',
+            'America/Sao_Paulo',
+            '--observation',
+            'Met recruiter',
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert FakeApiClient.captured_post_path == '/applications/99/steps'
+    assert FakeApiClient.captured_post_payload == {
+        'step_id': '1',
+        'step_date': '2026-05-11',
+        'start_time': '09:00',
+        'end_time': '10:00',
+        'timezone': 'America/Sao_Paulo',
+        'observation': 'Met recruiter',
+    }
+    assert (
+        'Added step: id=500 step=Initial Screen date=2026-05-11'
+        in result.output
+    )
+
+
+def test_application_steps_add_rejects_strict_step(monkeypatch, runner):
+    _setup(monkeypatch)
+    FakeApiClient.supports = _supports()
+    FakeApiClient.applications = [{'id': '99', 'finalized': False}]
+
+    result = runner.invoke(
+        app,
+        [
+            'applications',
+            'steps',
+            'add',
+            '99',
+            '--step',
+            'Offer',
+            '--date',
+            '2026-05-11',
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert 'Unknown step.' in result.output
+
+
+def test_application_steps_add_rejects_invalid_time_pairs(monkeypatch, runner):
+    _setup(monkeypatch)
+    FakeApiClient.supports = _supports()
+    FakeApiClient.applications = [{'id': '99', 'finalized': False}]
+
+    result = runner.invoke(
+        app,
+        [
+            'applications',
+            'steps',
+            'add',
+            '99',
+            '--step',
+            'Initial Screen',
+            '--date',
+            '2026-05-11',
+            '--start-time',
+            '09:00',
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert 'start-time and end-time must be provided together' in result.output
+
+
+def test_application_steps_edit_merges_existing_and_clear_flags(
+    monkeypatch, runner
+):
+    _setup(monkeypatch)
+    FakeApiClient.supports = _supports()
+    FakeApiClient.applications = [{'id': '99', 'finalized': False}]
+    FakeApiClient.application_steps = {
+        '99': [
+            {
+                'id': '500',
+                'step_id': '1',
+                'step_name': 'Initial Screen',
+                'step_date': '2026-05-11',
+                'start_time': '09:00',
+                'end_time': '10:00',
+                'timezone': 'America/Sao_Paulo',
+                'observation': 'Old note',
+            }
+        ]
+    }
+    FakeApiClient.step_updated_response = {
+        'id': '500',
+        'step_id': '2',
+        'step_name': 'Manager Interview',
+        'step_date': '2026-05-11',
+        'start_time': None,
+        'end_time': None,
+        'timezone': 'America/Sao_Paulo',
+        'observation': None,
+    }
+
+    result = runner.invoke(
+        app,
+        [
+            'applications',
+            'steps',
+            'edit',
+            '99',
+            '500',
+            '--step',
+            'Manager Interview',
+            '--clear',
+            'observation',
+            '--clear',
+            'time',
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert FakeApiClient.captured_put_path == '/applications/99/steps/500'
+    assert FakeApiClient.captured_put_payload == {
+        'step_id': '2',
+        'step_date': '2026-05-11',
+        'start_time': None,
+        'end_time': None,
+        'timezone': 'America/Sao_Paulo',
+        'observation': None,
+    }
+    assert (
+        'Updated step: id=500 step=Manager Interview date=2026-05-11'
+        in result.output
+    )
+
+
+def test_application_steps_delete_calls_correct_endpoint(monkeypatch, runner):
+    _setup(monkeypatch)
+    FakeApiClient.applications = [{'id': '99', 'finalized': False}]
+    FakeApiClient.application_steps = {
+        '99': [
+            {
+                'id': '500',
+                'step_id': '1',
+                'step_name': 'Initial Screen',
+                'step_date': '2026-05-11',
+                'start_time': None,
+                'end_time': None,
+                'timezone': None,
+                'observation': None,
+            }
+        ]
+    }
+
+    result = runner.invoke(
+        app,
+        ['applications', 'steps', 'delete', '99', '500'],
+    )
+
+    assert result.exit_code == 0
+    assert FakeApiClient.captured_delete_path == '/applications/99/steps/500'
+    assert 'Deleted step: id=500' in result.output
+
+
+def test_application_steps_edit_accepts_explicit_id_flags(monkeypatch, runner):
+    _setup(monkeypatch)
+    FakeApiClient.supports = _supports()
+    FakeApiClient.applications = [{'id': '99', 'finalized': False}]
+    FakeApiClient.application_steps = {
+        '99': [
+            {
+                'id': '500',
+                'step_id': '1',
+                'step_name': 'Initial Screen',
+                'step_date': '2026-05-11',
+                'start_time': '09:00',
+                'end_time': '10:00',
+                'timezone': 'America/Sao_Paulo',
+                'observation': 'Old note',
+            }
+        ]
+    }
+    FakeApiClient.step_updated_response = {
+        'id': '500',
+        'step_id': '2',
+        'step_name': 'Manager Interview',
+        'step_date': '2026-05-11',
+        'start_time': '15:00',
+        'end_time': '16:00',
+        'timezone': 'America/Sao_Paulo',
+        'observation': 'Old note',
+    }
+
+    result = runner.invoke(
+        app,
+        [
+            'applications',
+            'steps',
+            'edit',
+            '--application-id',
+            '99',
+            '--step-record-id',
+            '500',
+            '--step',
+            'Manager Interview',
+            '--start-time',
+            '15:00',
+            '--end-time',
+            '16:00',
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert FakeApiClient.captured_put_path == '/applications/99/steps/500'
+    assert FakeApiClient.captured_put_payload == {
+        'step_id': '2',
+        'step_date': '2026-05-11',
+        'start_time': '15:00',
+        'end_time': '16:00',
+        'timezone': 'America/Sao_Paulo',
+        'observation': 'Old note',
+    }
+
+
+def test_application_steps_edit_rejects_conflicting_ids(monkeypatch, runner):
+    _setup(monkeypatch)
+
+    result = runner.invoke(
+        app,
+        [
+            'applications',
+            'steps',
+            'edit',
+            '99',
+            '500',
+            '--application-id',
+            '100',
+            '--step-record-id',
+            '500',
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert 'Conflicting application id' in result.output
+
+
+def test_application_steps_delete_accepts_explicit_id_flags(
+    monkeypatch, runner
+):
+    _setup(monkeypatch)
+    FakeApiClient.applications = [{'id': '99', 'finalized': False}]
+    FakeApiClient.application_steps = {
+        '99': [
+            {
+                'id': '500',
+                'step_id': '1',
+                'step_name': 'Initial Screen',
+                'step_date': '2026-05-11',
+                'start_time': None,
+                'end_time': None,
+                'timezone': None,
+                'observation': None,
+            }
+        ]
+    }
+
+    result = runner.invoke(
+        app,
+        [
+            'applications',
+            'steps',
+            'delete',
+            '--application-id',
+            '99',
+            '--step-record-id',
+            '500',
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert FakeApiClient.captured_delete_path == '/applications/99/steps/500'
+
+
+@pytest.mark.parametrize(
+    'command', [['add'], ['edit', '500'], ['delete', '500']]
+)
+def test_application_step_mutations_reject_finalized_applications(
+    monkeypatch, runner, command
+):
+    _setup(monkeypatch)
+    FakeApiClient.supports = _supports()
+    FakeApiClient.applications = [{'id': '99', 'finalized': True}]
+    FakeApiClient.application_steps = {
+        '99': [
+            {
+                'id': '500',
+                'step_id': '1',
+                'step_name': 'Initial Screen',
+                'step_date': '2026-05-11',
+                'start_time': None,
+                'end_time': None,
+                'timezone': None,
+                'observation': None,
+            }
+        ]
+    }
+
+    args = ['applications', 'steps', *command, '99']
+    if command == ['add']:
+        args.extend(['--step', 'Initial Screen', '--date', '2026-05-11'])
+    else:
+        args = ['applications', 'steps', command[0], '99', command[1]]
+
+    result = runner.invoke(app, args)
+
+    assert result.exit_code == 1
+    assert 'already been finalized' in result.output
+
+
+def test_applications_finalize_posts_matching_payload(monkeypatch, runner):
+    _setup(monkeypatch)
+    FakeApiClient.supports = _supports()
+    FakeApiClient.finalized_response = {
+        'id': '99',
+        'company_name': 'Acme',
+        'role': 'Backend Engineer',
+        'salary_offer': 180000.0,
+        'last_step': {'name': 'Offer', 'date': '2026-05-18'},
+        'feedback': {'name': 'Accepted', 'date': '2026-05-18'},
+    }
+
+    result = runner.invoke(
+        app,
+        [
+            'applications',
+            'finalize',
+            '99',
+            '--step',
+            'Offer',
+            '--feedback',
+            'Accepted',
+            '--date',
+            '2026-05-18',
+            '--salary-offer',
+            '180000',
+            '--observation',
+            'Signed',
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert FakeApiClient.captured_post_path == '/applications/99/finalize'
+    assert FakeApiClient.captured_post_payload == {
+        'step_id': '9',
+        'feedback_id': '8',
+        'finalize_date': '2026-05-18',
+        'salary_offer': 180000.0,
+        'observation': 'Signed',
+    }
+    assert (
+        'Finalized application: id=99 company=Acme role=Backend Engineer'
+        in result.output
+    )
+    assert 'final_step=Offer' in result.output
+    assert 'feedback=Accepted' in result.output
+
+
+def test_applications_finalize_outputs_json(monkeypatch, runner):
+    _setup(monkeypatch)
+    FakeApiClient.supports = _supports()
+    FakeApiClient.finalized_response = {
+        'id': '99',
+        'company_name': 'Acme',
+        'role': 'Backend Engineer',
+        'salary_offer': None,
+        'last_step': {'name': 'Denied', 'date': '2026-05-18'},
+        'feedback': {'name': 'Rejected', 'date': '2026-05-18'},
+    }
+
+    result = runner.invoke(
+        app,
+        [
+            'applications',
+            'finalize',
+            '99',
+            '--step',
+            'Offer',
+            '--feedback',
+            'Rejected',
+            '--date',
+            '2026-05-18',
+            '--output-format',
+            'json',
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output)['id'] == '99'
+
+
+def test_applications_finalize_rejects_non_strict_steps(monkeypatch, runner):
+    _setup(monkeypatch)
+    FakeApiClient.supports = _supports()
+
+    result = runner.invoke(
+        app,
+        [
+            'applications',
+            'finalize',
+            '99',
+            '--step',
+            'Initial Screen',
+            '--feedback',
+            'Rejected',
+            '--date',
+            '2026-05-18',
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert 'Unknown step.' in result.output
+
+
 def test_login_error_on_state_mismatch(monkeypatch, runner):
     store = FakeStore()
     monkeypatch.setattr(cli_app, 'SessionStore', lambda: store)
@@ -377,6 +924,53 @@ def test_whoami_works_without_name(monkeypatch, runner):
     assert result.exit_code == 0
     assert 'username=ghost' in result.output
     assert '  name=' not in result.output
+
+
+def test_root_version_flag_prints_installed_version(monkeypatch, runner):
+    monkeypatch.setattr(cli_app, 'installed_version', lambda: '0.1.2')
+
+    result = runner.invoke(app, ['--version'])
+
+    assert result.exit_code == 0
+    assert result.output.strip() == '0.1.2'
+
+
+def test_version_command_prints_installed_and_published(monkeypatch, runner):
+    monkeypatch.setattr(version_module, 'installed_version', lambda: '0.1.2')
+
+    def fake_get(url, timeout):
+        assert url == 'https://pypi.org/pypi/applika-cli/json'
+        assert timeout == 10
+        request = httpx.Request('GET', url)
+        return httpx.Response(
+            200,
+            json={'info': {'version': '0.1.3'}},
+            request=request,
+        )
+
+    monkeypatch.setattr(version_module.httpx, 'get', fake_get)
+
+    result = runner.invoke(app, ['version'])
+
+    assert result.exit_code == 0
+    assert 'installed: 0.1.2' in result.output
+    assert 'published: 0.1.3' in result.output
+
+
+def test_version_command_handles_unavailable_pypi(monkeypatch, runner):
+    monkeypatch.setattr(version_module, 'installed_version', lambda: '0.1.2')
+
+    def fake_get(url, timeout):
+        request = httpx.Request('GET', url)
+        raise httpx.ConnectError('network down', request=request)
+
+    monkeypatch.setattr(version_module.httpx, 'get', fake_get)
+
+    result = runner.invoke(app, ['version'])
+
+    assert result.exit_code == 0
+    assert 'installed: 0.1.2' in result.output
+    assert 'published: unavailable' in result.output
 
 
 def test_skill_dry_run(monkeypatch, runner, tmp_path):

--- a/cli/uv.lock
+++ b/cli/uv.lock
@@ -36,7 +36,7 @@ wheels = [
 
 [[package]]
 name = "applika-cli"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
Add CLI support for application step management and finalization, enforce backend validation for final outcome combinations so invalid Offer/Accepted states do not reach the database, and add first-class OpenCode skill installation support.

## Type of Change
- [x] Feature
- [ ] Fix
- [x] Improvement
- [ ] Refactor
- [x] Documentation

## Included Changes
### Features
- Add `applika applications steps list/add/edit/delete` and `applika applications finalize`
- Add JSON output for step listing and finalization, plus `applika version`
- Add `~/.agents/skills` as a built-in `applika skill` install target for OpenCode

### Improvements
- Add explicit `--application-id` and `--step-record-id` aliases while keeping positional IDs backward compatible
- Enforce backend finalization rules for `Offer` plus `Accepted` and `salary_offer`
- Expand CLI and backend test coverage for the new flows and guards

## Testing
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] N/A

## Notes
- Backend integration tests could not be run locally in this session because Testcontainers could not reach the Docker daemon.

## Checklist
- [x] Self-review completed
- [x] CI passing
- [x] Ready to merge